### PR TITLE
feat(github): infraestrutura Spec ↔ GitHub Issue (Fase 2)

### DIFF
--- a/.ai/specs/CONVENTIONS.md
+++ b/.ai/specs/CONVENTIONS.md
@@ -296,7 +296,7 @@ A matriz completa "uma informação, um lar" (Spec/Issue/Project/Código/PR/Rele
 
 ## Relação entre templates e specs
 
-- `templates/` é a fonte canônica dos formatos: `table-spec` (T1), `rpc-spec` (T2), `page-spec` (T3), `component-spec`, `feature-spec` (T4), `adr-template` (T5), `proposal-template` (T6), `business-rule`, `analysis-report` (T7).
+- `templates/` é a fonte canônica dos formatos: `table-spec` (T1), `rpc-spec` (T2), `page-spec` (T3), `component-spec`, `feature-spec` (T4), `adr-template` (T5), `proposal-template` (T6), `business-rule`, `analysis-report` (T7), `issue-projection` (T8 — corpo da Issue canônica, seção 18.3).
 - Toda spec segue o template aplicável; desvios justificados no próprio arquivo.
 - Alterações em `CONVENTIONS.md`, `README.md` e `templates/`: proposta → aprovação → aplicação (nunca silenciosa).
 

--- a/.ai/specs/templates/issue-projection.md
+++ b/.ai/specs/templates/issue-projection.md
@@ -1,0 +1,44 @@
+# Template — Issue Projection (Spec → GitHub Issue)
+
+**Uso:** formato canônico do corpo da Issue canônica de uma proposta (ligação 1:1 — `CONVENTIONS.md` §18.2/§18.3; Blueprint v1.1-final §20). A projeção é gerada pelo sync (`scripts/spec-github/`); este template define o contrato.
+
+**Regras:**
+- O bloco entre `SPEC-PROJECTION:START` e `SPEC-PROJECTION:END` é a ÚNICA região que o Claude edita/regrava. É gerado a partir da Spec (fonte de verdade).
+- Conteúdo FORA do bloco — especialmente discussão humana — NUNCA é sobrescrito.
+- Comentários de sincronização de Claude carregam marker `<!-- sync:<evento> -->` para deduplicação (idempotência).
+- PRs linkam a Issue com `Part of #N` / `Related to #N` — **nunca** `Closes #N` (D-1).
+- Fechamento da Issue segue a distinção decisão × execução mecânica (`CONVENTIONS.md` §18.6, D-12).
+
+---
+
+```
+> **Spec:** `<ID>` · **Tipo:** <FEAT|ENH|REF|DEBT|SEC|TEST> · **Arquivo:** `.ai/specs/proposed/<categoria>/<ID>-<slug>.md`
+> **Status da Spec:** <PROPOSED|ACCEPTED|IMPLEMENTATION|IMPLEMENTED|REJECTED|SUPERSEDED> · **Prioridade:** ver Project · **Milestone:** <quando houver>
+
+<!-- SPEC-PROJECTION:START — bloco GERADO a partir da Spec. Claude atualiza esta seção; edições manuais aqui serão sobrescritas na próxima sincronização. -->
+## Problema
+
+<## Problem da Spec>
+
+## Estado proposto
+
+<## Proposed State da Spec>
+
+## Critérios de aceitação
+
+<## Acceptance Criteria da Spec>
+
+## Decisão
+
+<**Decision:** da Spec — ou "— (aguardando decisão humana)">
+
+<!-- SPEC-PROJECTION:END -->
+
+---
+Discussão operacional: progresso, bloqueios, aprovações e validações. (Conteúdo humano — NUNCA sobrescrito por Claude.)
+```
+
+**Campos complementares (fora do bloco, gerenciados no GitHub):**
+- Título: `[<ID>] <Título da Spec>` (Spec vence).
+- Labels: `spec:<ID>` + label do tipo (`feat` · `enhancement` · `refactor` · `technical-debt` · `security` · `testing`) + `spec-driven`.
+- Milestone: alvo de release (operacional; não existe na Spec).

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "dev": "vite",
     "lint": "eslint .",
     "supabase:migrations:apply": "bash scripts/apply-supabase-migrations.sh",
-    "cli": "node scripts/cli/index.js"
+    "cli": "node scripts/cli/index.js",
+    "spec:github:sync": "node scripts/spec-github/sync.js",
+    "spec:github:sync:dry": "node scripts/spec-github/sync.js --dry-run"
   }
 }

--- a/scripts/spec-github/__fixtures__/specs/archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md
+++ b/scripts/spec-github/__fixtures__/specs/archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md
@@ -1,0 +1,28 @@
+# DEBT-0004 — Reconciliar templates e convenções
+
+**Type:** DEBT
+**Status:** IMPLEMENTED
+**Title:** Reconciliar templates e convenções do Specification System
+**Issue:** #7
+**Implemented Through:** Fase 12
+
+## Problem
+
+Templates e convenções divergentes.
+
+## Proposed State
+
+Reconciliar templates com a governança.
+
+## Acceptance Criteria
+
+- [x] Templates alinhados.
+
+## Alternatives
+
+A — reconciliar · B — status quo
+**Decision:** A
+
+## References
+
+O-001/R-004/R-001

--- a/scripts/spec-github/__fixtures__/specs/proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md
+++ b/scripts/spec-github/__fixtures__/specs/proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md
@@ -1,0 +1,26 @@
+# DEBT-0001 — Versionar objetos sem DDL versionado
+
+**Type:** DEBT
+**Status:** PROPOSED
+**Title:** Versionar objetos sem DDL versionado
+
+## Problem
+
+Parte do schema real não possui DDL em nenhuma migration.
+
+## Proposed State
+
+Versionar os objetos com migration de baseline.
+
+## Acceptance Criteria
+
+- [ ] DDL versionado consistente com o catálogo.
+
+## Alternatives
+
+A — migration de baseline · B — manter status quo
+**Decision:** TBD
+
+## References
+
+N/A

--- a/scripts/spec-github/__fixtures__/specs/proposed/testing/TEST-0002-suites-seguranca-policies.md
+++ b/scripts/spec-github/__fixtures__/specs/proposed/testing/TEST-0002-suites-seguranca-policies.md
@@ -1,0 +1,27 @@
+# TEST-0002 — Suítes de segurança para policies não cobertas
+
+**Type:** TEST
+**Status:** PROPOSED
+**Title:** Suítes de segurança para policies não cobertas
+**Issue:** #42
+
+## Problem
+
+Policies sem cobertura de teste de segurança.
+
+## Proposed State
+
+Criar suítes para as policies não cobertas.
+
+## Acceptance Criteria
+
+- [ ] Suítes criadas e verdes.
+
+## Alternatives
+
+A — criar suítes · B — status quo
+**Decision:** TBD
+
+## References
+
+GAP-007/012

--- a/scripts/spec-github/lib/env.js
+++ b/scripts/spec-github/lib/env.js
@@ -1,0 +1,18 @@
+// Carregamento do token do GitHub: variável de ambiente GITHUB_TOKEN ou arquivo local .env.github
+// (NÃO versionado — coberto pelo .gitignore via `.env*`). Segurança: Blueprint v1.1-final §16.4.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function loadToken(repoRoot) {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+
+  const envFile = join(repoRoot, '.env.github')
+  if (!existsSync(envFile)) return null
+
+  for (const line of readFileSync(envFile, 'utf8').split(/\r?\n/)) {
+    const match = line.match(/^GITHUB_TOKEN\s*=\s*(.+)$/)
+    if (match && match[1].trim()) return match[1].trim()
+  }
+  return null
+}

--- a/scripts/spec-github/lib/github.js
+++ b/scripts/spec-github/lib/github.js
@@ -1,0 +1,66 @@
+// Cliente mínimo da GitHub REST API (Issues), sem dependências externas.
+// O token é injetado; o cliente é substituível nos testes (fetch impl).
+
+export class GitHubApiError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'GitHubApiError'
+    this.status = status
+  }
+}
+
+export class GitHubClient {
+  constructor({ token, owner, repo, fetchImpl = globalThis.fetch, baseUrl = 'https://api.github.com' }) {
+    this.token = token
+    this.owner = owner
+    this.repo = repo
+    this.fetchImpl = fetchImpl
+    this.baseUrl = baseUrl
+  }
+
+  async request(method, path, body) {
+    const url = `${this.baseUrl}${path}`
+    const response = await this.fetchImpl(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    if (response.status === 404) return null
+    if (!response.ok) {
+      throw new GitHubApiError(`GitHub API ${method} ${path} → HTTP ${response.status}`, response.status)
+    }
+    return response.json()
+  }
+
+  /** Busca o Issue por número; null quando não existe. */
+  getIssue(number) {
+    return this.request('GET', `/repos/${this.owner}/${this.repo}/issues/${number}`)
+  }
+
+  /** Busca Issues pela label spec:<ID> (exclui PRs). */
+  async findIssuesByLabel(label) {
+    const issues = await this.request(
+      'GET',
+      `/repos/${this.owner}/${this.repo}/issues?state=all&per_page=100&labels=${encodeURIComponent(label)}`
+    )
+    if (!Array.isArray(issues)) return []
+    return issues.filter((i) => !i.pull_request)
+  }
+
+  createIssue({ title, body, labels }) {
+    return this.request('POST', `/repos/${this.owner}/${this.repo}/issues`, { title, body, labels })
+  }
+
+  updateIssue(number, { title, body }) {
+    return this.request('PATCH', `/repos/${this.owner}/${this.repo}/issues/${number}`, { title, body })
+  }
+
+  setLabels(number, labels) {
+    return this.request('PUT', `/repos/${this.owner}/${this.repo}/issues/${number}/labels`, { labels })
+  }
+}

--- a/scripts/spec-github/lib/projection.js
+++ b/scripts/spec-github/lib/projection.js
@@ -1,0 +1,91 @@
+// Projeção Spec → Issue (título, labels, corpo com bloco SPEC-PROJECTION).
+// Contrato: Blueprint v1.1-final §20 e .ai/specs/templates/issue-projection.md.
+
+export const MARKER_START = '<!-- SPEC-PROJECTION:START'
+export const MARKER_END = '<!-- SPEC-PROJECTION:END'
+
+const TYPE_LABELS = {
+  FEAT: 'feat',
+  ENH: 'enhancement',
+  REF: 'refactor',
+  DEBT: 'technical-debt',
+  SEC: 'security',
+  TEST: 'testing',
+}
+
+export function specLabel(id) {
+  return `spec:${id}`
+}
+
+export function typeLabel(type) {
+  return TYPE_LABELS[type] ?? null
+}
+
+export function labels(spec) {
+  const set = ['spec-driven', specLabel(spec.id)]
+  const type = typeLabel(spec.type)
+  if (type) set.push(type)
+  return set
+}
+
+export function issueTitle(spec) {
+  return `[${spec.id}] ${spec.title ?? spec.id}`
+}
+
+function sectionOrFallback(content, fallback) {
+  return content ?? fallback
+}
+
+export function buildProjectionBlock(spec) {
+  const decision = spec.decision && spec.decision !== 'TBD' ? spec.decision : '— (aguardando decisão humana)'
+  return [
+    '## Problema',
+    '',
+    sectionOrFallback(spec.problem, '(sem seção no arquivo)'),
+    '',
+    '## Estado proposto',
+    '',
+    sectionOrFallback(spec.proposed, '(sem seção no arquivo)'),
+    '',
+    '## Critérios de aceitação',
+    '',
+    sectionOrFallback(spec.acs, '(sem seção no arquivo)'),
+    '',
+    '## Decisão',
+    '',
+    decision,
+  ].join('\n')
+}
+
+export function buildBody(spec) {
+  return [
+    `> **Spec:** \`${spec.id}\` · **Tipo:** ${spec.type ?? '?'} · **Arquivo:** \`.ai/specs/${spec.path}\``,
+    `> **Status da Spec:** ${spec.status ?? '?'} · **Prioridade:** ver Project · **Milestone:** —`,
+    '',
+    `${MARKER_START} — bloco GERADO a partir da Spec. Claude atualiza esta seção; edições manuais aqui serão sobrescritas na próxima sincronização. -->`,
+    buildProjectionBlock(spec),
+    MARKER_END,
+    '',
+    '---',
+    '',
+    'Discussão operacional: progresso, bloqueios, aprovações e validações. (Conteúdo humano — NUNCA sobrescrito por Claude.)',
+  ].join('\n')
+}
+
+/**
+ * Substitui o bloco projetado no corpo existente do Issue.
+ * Retorna null quando o corpo não tem os marcadores (edição manual/divergência — não sobrescrever).
+ */
+export function replaceProjectionBlock(existingBody, newBody) {
+  if (typeof existingBody !== 'string') return null
+  const startIdx = existingBody.indexOf(MARKER_START)
+  const endIdx = existingBody.indexOf(MARKER_END)
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null
+
+  const newStart = newBody.indexOf(MARKER_START)
+  const newEnd = newBody.indexOf(MARKER_END)
+  if (newStart === -1 || newEnd === -1) return null
+
+  const block = newBody.slice(newStart, newEnd + MARKER_END.length)
+  return existingBody.slice(0, startIdx) + block + existingBody.slice(endIdx + MARKER_END.length)
+}

--- a/scripts/spec-github/lib/projection.test.js
+++ b/scripts/spec-github/lib/projection.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MARKER_END,
+  MARKER_START,
+  buildBody,
+  buildProjectionBlock,
+  issueTitle,
+  labels,
+  replaceProjectionBlock,
+  specLabel,
+  typeLabel,
+} from './projection.js'
+
+const spec = {
+  id: 'DEBT-0001',
+  type: 'DEBT',
+  status: 'PROPOSED',
+  title: 'Versionar objetos sem DDL versionado',
+  decision: 'TBD',
+  path: 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md',
+  problem: 'Parte do schema não tem DDL.',
+  proposed: 'Versionar os objetos.',
+  acs: '- [ ] DDL versionado.',
+}
+
+describe('projection', () => {
+  it('mapeia labels a partir do ID e do tipo', () => {
+    expect(specLabel('DEBT-0001')).toBe('spec:DEBT-0001')
+    expect(typeLabel('DEBT')).toBe('technical-debt')
+    expect(typeLabel('FEAT')).toBe('feat')
+    expect(typeLabel('TEST')).toBe('testing')
+    expect(typeLabel('XX')).toBeNull()
+    expect(labels(spec)).toEqual(['spec-driven', 'spec:DEBT-0001', 'technical-debt'])
+  })
+
+  it('gera o título [ID] Título', () => {
+    expect(issueTitle(spec)).toBe('[DEBT-0001] Versionar objetos sem DDL versionado')
+  })
+
+  it('gera o corpo com bloco SPEC-PROJECTION, seções e decisão', () => {
+    const body = buildBody(spec)
+    expect(body).toContain(MARKER_START)
+    expect(body).toContain(MARKER_END)
+    expect(body).toContain('`DEBT-0001`')
+    expect(body).toContain('.ai/specs/proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+    expect(body).toContain('## Problema')
+    expect(body).toContain('Parte do schema não tem DDL.')
+    expect(body).toContain('## Critérios de aceitação')
+    expect(body).toContain('— (aguardando decisão humana)')
+    expect(body).toContain('NUNCA sobrescrito')
+  })
+
+  it('projeta a decisão escolhida quando não é TBD', () => {
+    expect(buildProjectionBlock({ ...spec, decision: 'A' })).toContain('## Decisão')
+    expect(buildProjectionBlock({ ...spec, decision: 'A' })).toContain('A')
+  })
+
+  it('substitui apenas o interior do bloco, preservando o conteúdo humano fora dele', () => {
+    const existing = [
+      '> **Spec:** `DEBT-0001`',
+      '',
+      `${MARKER_START} — antigo -->`,
+      'conteúdo antigo',
+      MARKER_END,
+      '',
+      '---',
+      '',
+      'Comentário humano preservado.',
+    ].join('\n')
+    const updated = replaceProjectionBlock(existing, buildBody({ ...spec, problem: 'Problema novo.' }))
+    expect(updated).toContain('Problema novo.')
+    expect(updated).not.toContain('conteúdo antigo')
+    expect(updated).toContain('Comentário humano preservado.')
+    expect(updated.indexOf(MARKER_START)).toBeGreaterThan(-1)
+    expect(updated.indexOf(MARKER_END)).toBeGreaterThan(updated.indexOf(MARKER_START))
+  })
+
+  it('retorna null quando o corpo existente não tem os marcadores (divergência — não sobrescrever)', () => {
+    expect(replaceProjectionBlock('corpo sem marcadores', buildBody(spec))).toBeNull()
+    expect(replaceProjectionBlock(null, buildBody(spec))).toBeNull()
+  })
+})

--- a/scripts/spec-github/lib/specs.js
+++ b/scripts/spec-github/lib/specs.js
@@ -1,0 +1,102 @@
+// Leitura e parsing das Specs de proposed/ e archive/ (MeuFenil Spec-Driven GitHub Operations).
+// Convenções: .ai/specs/CONVENTIONS.md §4, §8, §18 e templates/proposal-template.md.
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join, basename, dirname } from 'node:path'
+
+const CATEGORIES = ['features', 'enhancements', 'refactors', 'technical-debt', 'security', 'testing']
+const ARCHIVE_AREAS = ['implemented', 'rejected', 'superseded']
+export const TERMINAL_STATUSES = ['IMPLEMENTED', 'REJECTED', 'SUPERSEDED']
+
+const ID_RE = /^([A-Z]+-\d{4})-/
+
+function extractSection(text, name) {
+  const match = text.match(new RegExp(`## ${name}\\s*\\n([\\s\\S]*?)(?=\\n## |\\n---\\s*\\n|$)`, 'm'))
+  if (!match) return null
+  const content = match[1].trim()
+  return content.length > 0 ? content : null
+}
+
+export function parseSpec(text, relPath) {
+  const fileName = basename(relPath)
+  const idMatch = fileName.match(ID_RE)
+  const typeMatch = text.match(/^\*\*Type:\*\*\s*(\S+)/m)
+  const statusMatch = text.match(/^\*\*Status:\*\*\s*(\S+)/m)
+  const titleMatch = text.match(/^\*\*Title:\*\*\s*(.+)$/m)
+  const issueMatch = text.match(/^\*\*Issue:\*\*\s*#?(\d+)/m)
+  const decisionMatch = text.match(/## Alternatives[\s\S]*?\*\*Decision:\*\*\s*([^\n]+)/)
+
+  if (!idMatch) return null
+
+  return {
+    id: idMatch[1],
+    type: typeMatch ? typeMatch[1] : null,
+    status: statusMatch ? statusMatch[1] : null,
+    title: titleMatch ? titleMatch[1].trim() : null,
+    issue: issueMatch ? Number(issueMatch[1]) : null,
+    decision: decisionMatch ? decisionMatch[1].trim() : null,
+    path: relPath,
+    problem: extractSection(text, 'Problem'),
+    proposed: extractSection(text, 'Proposed State'),
+    acs: extractSection(text, 'Acceptance Criteria'),
+  }
+}
+
+function specFilesUnder(dir) {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.md') && e.name !== 'index.md')
+    .map((e) => join(dir, e.name))
+}
+
+/**
+ * Lista todas as Specs (ativas de proposed/ e terminais de archive/).
+ * @param {string} baseDir — caminho de .ai/specs
+ */
+export function listSpecs(baseDir) {
+  const specs = []
+
+  for (const category of CATEGORIES) {
+    const proposedDir = join(baseDir, 'proposed', category)
+    for (const filePath of specFilesUnder(proposedDir)) {
+      const relPath = filePath.replace(/\\/g, '/').replace(baseDir.replace(/\\/g, '/') + '/', '')
+      const spec = parseSpec(readFileSync(filePath, 'utf8'), relPath)
+      if (spec) specs.push({ ...spec, filePath, area: 'proposed', category })
+    }
+  }
+
+  for (const area of ARCHIVE_AREAS) {
+    for (const category of CATEGORIES) {
+      const dir = join(baseDir, 'archive', area, category)
+      for (const filePath of specFilesUnder(dir)) {
+        const relPath = filePath.replace(/\\/g, '/').replace(baseDir.replace(/\\/g, '/') + '/', '')
+        const spec = parseSpec(readFileSync(filePath, 'utf8'), relPath)
+        if (spec) specs.push({ ...spec, filePath, area: `archive/${area}`, category })
+      }
+    }
+  }
+
+  return specs.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+/**
+ * Retorna o novo conteúdo do arquivo quando o campo Issue: precisa ser criado/corrigido;
+ * null quando já está correto; false quando não há âncora (campo Status:) para inserir.
+ */
+export function backfillIssueNumber(spec, issueNumber) {
+  const text = readFileSync(spec.filePath, 'utf8')
+  const line = `**Issue:** #${issueNumber}`
+  if (new RegExp(`^\\*\\*Issue:\\*\\*\\s*#?${issueNumber}\\s*$`, 'm').test(text)) return null
+
+  const hasField = /^\*\*Issue:\*\*.*$/m.test(text)
+  let updated
+  if (hasField) {
+    updated = text.replace(/^\*\*Issue:\*\*.*$/m, line)
+  } else {
+    const anchor = /^\*\*Status:\*\*.*$/m
+    if (!anchor.test(text)) return false
+    updated = text.replace(anchor, (m) => `${m}\n${line}`)
+  }
+  if (updated === text) return false
+  return updated
+}

--- a/scripts/spec-github/lib/specs.test.js
+++ b/scripts/spec-github/lib/specs.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { backfillIssueNumber, listSpecs, parseSpec } from './specs.js'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__', 'specs')
+
+const SAMPLE = `# DEBT-0001 — Versionar objetos sem DDL versionado
+
+**Type:** DEBT
+**Status:** PROPOSED
+**Title:** Versionar objetos sem DDL versionado
+
+## Problem
+
+Parte do schema não tem DDL.
+
+## Proposed State
+
+Versionar os objetos.
+
+## Acceptance Criteria
+
+- [ ] DDL versionado.
+
+## Alternatives
+
+A — migration de baseline · B — status quo
+**Decision:** TBD
+
+## References
+
+N/A
+`
+
+describe('specs', () => {
+  it('extrai header e seções de uma Spec', () => {
+    const spec = parseSpec(SAMPLE, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+    expect(spec.id).toBe('DEBT-0001')
+    expect(spec.type).toBe('DEBT')
+    expect(spec.status).toBe('PROPOSED')
+    expect(spec.title).toBe('Versionar objetos sem DDL versionado')
+    expect(spec.issue).toBeNull()
+    expect(spec.decision).toBe('TBD')
+    expect(spec.problem).toContain('Parte do schema não tem DDL.')
+    expect(spec.proposed).toContain('Versionar os objetos.')
+    expect(spec.acs).toContain('- [ ] DDL versionado.')
+  })
+
+  it('lista Specs de proposed/ e archive/ ordenadas por ID', () => {
+    const specs = listSpecs(FIXTURES)
+    expect(specs.map((s) => s.id)).toEqual(['DEBT-0001', 'DEBT-0004', 'TEST-0002'])
+    expect(specs.find((s) => s.id === 'DEBT-0001').area).toBe('proposed')
+    expect(specs.find((s) => s.id === 'DEBT-0004').area).toBe('archive/implemented')
+    expect(specs.find((s) => s.id === 'TEST-0002').issue).toBe(42)
+  })
+
+  it('backfill: insere o campo Issue após Status', () => {
+    const spec = parseSpec(SAMPLE, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+    spec.filePath = join(FIXTURES, 'proposed', 'technical-debt', 'DEBT-0001-ddl-nao-versionado.md')
+    const updated = backfillIssueNumber(spec, 12)
+    expect(updated).toContain('**Issue:** #12')
+    expect(updated.indexOf('**Issue:** #12')).toBeGreaterThan(updated.indexOf('**Status:** PROPOSED'))
+  })
+
+  it('backfill: null quando o número já está correto', () => {
+    const file42 = join(FIXTURES, 'proposed', 'testing', 'TEST-0002-suites-seguranca-policies.md')
+    expect(backfillIssueNumber({ filePath: file42 }, 42)).toBeNull()
+  })
+
+  it('backfill: corrige número divergente', () => {
+    const file42 = join(FIXTURES, 'proposed', 'testing', 'TEST-0002-suites-seguranca-policies.md')
+    const spec = listSpecs(FIXTURES).find((s) => s.id === 'TEST-0002')
+    const updated = backfillIssueNumber(spec, 8)
+    expect(updated).toContain('**Issue:** #8')
+    expect(updated).not.toContain('#42')
+    void file42
+  })
+})

--- a/scripts/spec-github/sync.js
+++ b/scripts/spec-github/sync.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Sync Spec ↔ GitHub Issue (Fase 2 — Blueprint v1.1-final §20).
+//
+// IDEMPOTENTE: executar duas vezes não cria duas Issues (chave: campo `Issue:` no frontmatter
+// ou busca por label `spec:<ID>`) e não duplica comentários.
+//
+// DIVERGÊNCIA (nunca corrigir silenciosamente — CONVENTIONS §18.5 / D-12 CASO 3):
+//   - Issue fechada com Spec ativa            → reporta, não toca
+//   - Issue aberta com Spec terminal          → reporta (fechamento é ato explícito do workflow)
+//   - corpo do Issue sem SPEC-PROJECTION      → reporta, não sobrescreve corpo
+//   - mais de um Issue com a label spec:<ID>  → reporta, não toca
+//
+// Uso:
+//   node scripts/spec-github/sync.js                 # requer GITHUB_TOKEN (env ou .env.github)
+//   node scripts/spec-github/sync.js --dry-run       # pré-visualiza local (sem token: só leitura local)
+
+import { writeFileSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+import { listSpecs, backfillIssueNumber, TERMINAL_STATUSES } from './lib/specs.js'
+import { buildBody, issueTitle, labels, replaceProjectionBlock, specLabel } from './lib/projection.js'
+import { GitHubClient, GitHubApiError } from './lib/github.js'
+import { loadToken } from './lib/env.js'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+function parseArgs(argv) {
+  const args = { dryRun: false, baseDir: join(REPO_ROOT, '.ai', 'specs'), repo: 'lucasmm96/meufenil' }
+  for (const arg of argv) {
+    if (arg === '--dry-run') args.dryRun = true
+    else if (arg.startsWith('--base-dir=')) args.baseDir = resolve(arg.slice('--base-dir='.length))
+    else if (arg.startsWith('--repo=')) args.repo = arg.slice('--repo='.length)
+  }
+  return args
+}
+
+function applyBackfill(spec, number, dryRun) {
+  const updated = backfillIssueNumber(spec, number)
+  if (updated === null) return 'already'
+  if (updated === false) return 'no-status-anchor'
+  if (!dryRun) writeFileSync(spec.filePath, updated)
+  return 'backfilled'
+}
+
+/**
+ * Executa a sincronização declarativa. Retorna relatório por Spec:
+ * { id, area, action: 'create'|'update'|'ok'|'local-preview', number, divergences: [] }
+ */
+export async function runSync({ token, owner, repo, baseDir, dryRun = false, client = null }) {
+  const specs = listSpecs(baseDir)
+  const api = client ?? (token ? new GitHubClient({ token, owner, repo }) : null)
+  const report = []
+
+  for (const spec of specs) {
+    const entry = { id: spec.id, area: spec.area, action: 'ok', number: spec.issue, divergences: [] }
+    const desired = { title: issueTitle(spec), body: buildBody(spec), labels: labels(spec) }
+
+    if (!api) {
+      entry.action = spec.issue ? 'local-preview (Issue existente — diff indisponível sem token)' : 'local-preview (criaria Issue)'
+      report.push(entry)
+      continue
+    }
+
+    let existing = null
+    try {
+      if (spec.issue) {
+        existing = await api.getIssue(spec.issue)
+        if (!existing) {
+          entry.divergences.push(`Issue #${spec.issue} do frontmatter não existe no GitHub`)
+          const byLabel = await api.findIssuesByLabel(specLabel(spec.id))
+          if (byLabel.length === 1) existing = byLabel[0]
+          else if (byLabel.length > 1) entry.divergences.push(`múltiplas Issues com label ${specLabel(spec.id)}`)
+        }
+      } else {
+        const byLabel = await api.findIssuesByLabel(specLabel(spec.id))
+        if (byLabel.length === 1) existing = byLabel[0]
+        else if (byLabel.length > 1) entry.divergences.push(`múltiplas Issues com label ${specLabel(spec.id)}`)
+      }
+    } catch (error) {
+      if (error instanceof GitHubApiError) throw error
+      throw error
+    }
+
+    if (!existing) {
+      if (dryRun) {
+        entry.action = 'create (dry-run)'
+        report.push(entry)
+        continue
+      }
+      const created = await api.createIssue(desired)
+      entry.action = 'create'
+      entry.number = created.number
+      entry.backfill = applyBackfill(spec, created.number, dryRun)
+      report.push(entry)
+      continue
+    }
+
+    entry.number = existing.number
+
+    if (existing.state === 'closed' && !TERMINAL_STATUSES.includes(spec.status)) {
+      entry.divergences.push(`Issue fechada mas Spec está ${spec.status} — D-12 CASO 3: não reverter nem aceitar; decidir com o autor`)
+    }
+    if (existing.state === 'open' && TERMINAL_STATUSES.includes(spec.status)) {
+      entry.divergences.push(`Spec ${spec.status} mas Issue aberta — fechamento é ato explícito do workflow (D-12), não executado pelo sync`)
+    }
+
+    let bodyChanged = false
+    const mergedBody = replaceProjectionBlock(existing.body, desired.body)
+    if (mergedBody === null) {
+      entry.divergences.push('corpo sem marcadores SPEC-PROJECTION — não sobrescrever (possível edição manual)')
+    } else if (mergedBody !== existing.body) {
+      bodyChanged = true
+    }
+
+    const titleChanged = existing.title !== desired.title
+    const labelsChanged =
+      JSON.stringify([...(existing.labels ?? []).map((l) => l.name)].sort()) !== JSON.stringify([...desired.labels].sort())
+
+    if (bodyChanged || titleChanged || labelsChanged) {
+      if (dryRun) {
+        entry.action = 'update (dry-run)'
+      } else {
+        await api.updateIssue(existing.number, { title: desired.title, body: mergedBody ?? existing.body })
+        await api.setLabels(existing.number, desired.labels)
+        entry.action = 'update'
+      }
+    }
+
+    if ((!spec.issue || spec.issue !== existing.number) && !dryRun) {
+      entry.backfill = applyBackfill(spec, existing.number, dryRun)
+      if (entry.backfill === 'backfilled' && entry.action === 'ok') entry.action = 'backfill'
+    }
+    report.push(entry)
+  }
+
+  return report
+}
+
+function printReport(report, dryRun) {
+  console.log(`\nSpec ↔ Issue sync${dryRun ? ' (DRY-RUN)' : ''} — ${report.length} specs\n`)
+  for (const entry of report) {
+    const line = [
+      entry.id.padEnd(12),
+      (entry.area ?? '').padEnd(18),
+      String(entry.action).padEnd(46),
+      entry.number ? `#${entry.number}` : '',
+      entry.backfill ? `[${entry.backfill}]` : '',
+    ].join('  ')
+    console.log(line)
+    for (const d of entry.divergences) console.log(`  ⚠ ${d}`)
+  }
+  const divergences = report.reduce((n, e) => n + e.divergences.length, 0)
+  console.log(`\nDivergências: ${divergences}`)
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2))
+  const [owner, repo] = args.repo.split('/')
+  const token = loadToken(REPO_ROOT)
+  if (!token && !args.dryRun) {
+    console.error('GITHUB_TOKEN ausente — defina a variável de ambiente ou crie .env.github (não versionado).')
+    process.exit(1)
+  }
+  try {
+    const report = await runSync({ token, owner, repo, baseDir: args.baseDir, dryRun: args.dryRun })
+    printReport(report, args.dryRun)
+  } catch (error) {
+    if (error instanceof GitHubApiError) {
+      console.error(`Falha de API (HTTP ${error.status}): ${error.message}`)
+    } else {
+      console.error(error)
+    }
+    process.exit(1)
+  }
+}

--- a/scripts/spec-github/sync.test.js
+++ b/scripts/spec-github/sync.test.js
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runSync } from './sync.js'
+import { GitHubClient } from './lib/github.js'
+import { MARKER_START, buildBody } from './lib/projection.js'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'specs')
+
+function copyFixture(tempBase, rel) {
+  const dest = join(tempBase, rel)
+  mkdirSync(dirname(dest), { recursive: true })
+  copyFileSync(join(FIXTURES, rel), dest)
+  return dest
+}
+
+/** Fake da GitHub API (Issues) em memória, com rastreio de chamadas. */
+function createFakeApi() {
+  const issues = new Map()
+  let nextNumber = 1
+  const calls = []
+
+  const respond = (status, data) => ({ status, ok: status >= 200 && status < 300, json: async () => data })
+
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url: String(url), init })
+    const u = new URL(url)
+    const method = init.method ?? 'GET'
+    const base = '/repos/o/r'
+
+    if (method === 'POST' && u.pathname === `${base}/issues`) {
+      const body = JSON.parse(init.body)
+      const number = nextNumber++
+      const issue = {
+        number,
+        state: 'open',
+        title: body.title,
+        body: body.body,
+        labels: (body.labels ?? []).map((name) => ({ name })),
+      }
+      issues.set(number, issue)
+      return respond(201, issue)
+    }
+
+    const single = u.pathname.match(/^\/repos\/o\/r\/issues\/(\d+)$/)
+    if (single && method === 'GET') {
+      const n = Number(single[1])
+      return issues.has(n) ? respond(200, issues.get(n)) : respond(404, { message: 'Not Found' })
+    }
+    if (single && method === 'PATCH') {
+      const n = Number(single[1])
+      if (!issues.has(n)) return respond(404, { message: 'Not Found' })
+      const body = JSON.parse(init.body)
+      const issue = issues.get(n)
+      if (body.title !== undefined) issue.title = body.title
+      if (body.body !== undefined) issue.body = body.body
+      return respond(200, issue)
+    }
+
+    const labelsPath = u.pathname.match(/^\/repos\/o\/r\/issues\/(\d+)\/labels$/)
+    if (labelsPath && method === 'PUT') {
+      const n = Number(labelsPath[1])
+      const body = JSON.parse(init.body)
+      issues.get(n).labels = body.labels.map((name) => ({ name }))
+      return respond(200, body)
+    }
+
+    if (method === 'GET' && u.pathname === `${base}/issues`) {
+      const label = u.searchParams.get('labels')
+      const list = [...issues.values()].filter(
+        (i) => label === null || (i.labels ?? []).some((l) => l.name === label)
+      )
+      return respond(200, list)
+    }
+
+    return respond(404, { message: 'Not Found' })
+  }
+
+  const seed = (issue) => {
+    issues.set(issue.number, issue)
+  }
+
+  return { fetchImpl, issues, calls, seed }
+}
+
+function makeClient(api) {
+  return new GitHubClient({ token: 'test-token', owner: 'o', repo: 'r', fetchImpl: api.fetchImpl })
+}
+
+function makeTempBase() {
+  return mkdtempSync(join(tmpdir(), 'spec-github-'))
+}
+
+describe('sync Spec ↔ Issue', () => {
+  let tempDirs = []
+
+  beforeEach(() => {
+    tempDirs = []
+  })
+
+  afterEach(() => {
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+  })
+
+  function tempBase() {
+    const dir = makeTempBase()
+    tempDirs.push(dir)
+    return dir
+  }
+
+  it('cria a Issue para Spec sem Issue e preenche o frontmatter', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+
+    expect(report[0].action).toBe('create')
+    expect(report[0].number).toBe(1)
+    expect(report[0].backfill).toBe('backfilled')
+    expect(report[0].divergences).toEqual([])
+    const file = readFileSync(join(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md'), 'utf8')
+    expect(file).toContain('**Issue:** #1')
+    const issue = api.issues.get(1)
+    expect(issue.title).toBe('[DEBT-0001] Versionar objetos sem DDL versionado')
+    expect(issue.labels.map((l) => l.name).sort()).toEqual(['spec-driven', 'spec:DEBT-0001', 'technical-debt'].sort())
+    expect(issue.body).toContain(MARKER_START)
+  })
+
+  it('é idempotente: segunda execução não cria nem altera nada', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    const first = await runSync({ client: makeClient(api), baseDir: base })
+    expect(first[0].action).toBe('create')
+
+    const mutateCalls = api.calls.length
+    const second = await runSync({ client: makeClient(api), baseDir: base })
+    expect(second[0].action).toBe('ok')
+    expect(second[0].divergences).toEqual([])
+    expect(api.issues.size).toBe(1)
+    expect(api.calls.slice(mutateCalls).filter((c) => !c.init.method || c.init.method !== 'GET').length).toBe(0)
+  })
+
+  it('atualiza o bloco projetado quando a Spec muda, preservando o conteúdo humano', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    const file = copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    await runSync({ client: makeClient(api), baseDir: base })
+
+    const issue = api.issues.get(1)
+    issue.body = issue.body.replace('Discussão operacional:', 'Discussão operacional:\n\nComentário do autor sobre o problema.')
+
+    let text = readFileSync(file, 'utf8')
+    writeFileSync(file, text.replace('Parte do schema real não possui DDL em nenhuma migration.', 'Problema atualizado com novo contexto.'))
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    expect(report[0].action).toBe('update')
+    expect(api.issues.get(1).body).toContain('Problema atualizado com novo contexto.')
+    expect(api.issues.get(1).body).toContain('Comentário do autor sobre o problema.')
+  })
+
+  it('CASO 3: Issue fechada com Spec ativa → divergência reportada, nada revertido', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    api.seed({
+      number: 5,
+      state: 'closed',
+      title: '[DEBT-0001] Versionar objetos sem DDL versionado',
+      body: buildBody({
+        id: 'DEBT-0001',
+        type: 'DEBT',
+        status: 'PROPOSED',
+        title: 'Versionar objetos sem DDL versionado',
+        decision: 'TBD',
+        path: 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md',
+        problem: 'Parte do schema real não possui DDL em nenhuma migration.',
+        proposed: 'Versionar os objetos com migration de baseline.',
+        acs: '- [ ] DDL versionado consistente com o catálogo.',
+      }),
+      labels: [{ name: 'spec:DEBT-0001' }, { name: 'spec-driven' }, { name: 'technical-debt' }],
+    })
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    expect(report[0].divergences.join(' ')).toContain('CASO 3')
+    expect(api.issues.get(5).state).toBe('closed')
+    expect(api.calls.every((c) => c.init.method !== 'POST')).toBe(true)
+  })
+
+  it('Spec terminal com Issue aberta → divergência reportada; sync não fecha a Issue (D-12)', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md')
+
+    const specText = readFileSync(join(base, 'archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md'), 'utf8')
+    const spec = {
+      id: 'DEBT-0004',
+      type: 'DEBT',
+      status: 'IMPLEMENTED',
+      title: 'Reconciliar templates e convenções do Specification System',
+      decision: 'A',
+      path: 'archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md',
+      problem: 'Templates e convenções divergentes.',
+      proposed: 'Reconciliar templates com a governança.',
+      acs: '- [x] Templates alinhados.',
+    }
+    api.seed({
+      number: 7,
+      state: 'open',
+      title: '[DEBT-0004] Reconciliar templates e convenções do Specification System',
+      body: buildBody(spec),
+      labels: [{ name: 'spec:DEBT-0004' }, { name: 'spec-driven' }, { name: 'technical-debt' }],
+    })
+    void specText
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    expect(report[0].divergences.join(' ')).toContain('fechamento é ato explícito')
+    expect(api.issues.get(7).state).toBe('open')
+  })
+
+  it('corpo sem marcadores → divergência; corpo NÃO é sobrescrito', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    api.seed({
+      number: 3,
+      state: 'open',
+      title: '[DEBT-0001] Versionar objetos sem DDL versionado',
+      body: 'Issue criado manualmente, sem bloco projetado.',
+      labels: [{ name: 'spec:DEBT-0001' }, { name: 'spec-driven' }, { name: 'technical-debt' }],
+    })
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    expect(report[0].divergences.join(' ')).toContain('sem marcadores')
+    expect(api.issues.get(3).body).toBe('Issue criado manualmente, sem bloco projetado.')
+  })
+
+  it('frontmatter com número errado é corrigido para o Issue encontrado por label', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/testing/TEST-0002-suites-seguranca-policies.md')
+
+    const spec = {
+      id: 'TEST-0002',
+      type: 'TEST',
+      status: 'PROPOSED',
+      title: 'Suítes de segurança para policies não cobertas',
+      decision: 'TBD',
+      path: 'proposed/testing/TEST-0002-suites-seguranca-policies.md',
+      problem: 'Policies sem cobertura de teste de segurança.',
+      proposed: 'Criar suítes para as policies não cobertas.',
+      acs: '- [ ] Suítes criadas e verdes.',
+    }
+    api.seed({
+      number: 8,
+      state: 'open',
+      title: '[TEST-0002] Suítes de segurança para policies não cobertas',
+      body: buildBody(spec),
+      labels: [{ name: 'spec:TEST-0002' }, { name: 'spec-driven' }, { name: 'testing' }],
+    })
+
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    const entry = report.find((e) => e.id === 'TEST-0002')
+    expect(entry.divergences.join(' ')).toContain('não existe no GitHub')
+    expect(entry.backfill).toBe('backfilled')
+    const file = readFileSync(join(base, 'proposed/testing/TEST-0002-suites-seguranca-policies.md'), 'utf8')
+    expect(file).toContain('**Issue:** #8')
+    expect(file).not.toContain('**Issue:** #42')
+  })
+
+  it('dry-run sem token: pré-visual local, sem chamadas de API e sem escrita', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+
+    const report = await runSync({ token: null, client: null, baseDir: base, dryRun: true })
+    expect(report[0].action).toContain('local-preview')
+    expect(api.calls.length).toBe(0)
+    const file = readFileSync(join(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md'), 'utf8')
+    expect(file).not.toContain('**Issue:**')
+  })
+
+  it('aceita base-dir com fixtures parciais sem quebrar (arquivos não-spec são ignorados)', async () => {
+    const api = createFakeApi()
+    const base = tempBase()
+    copyFixture(base, 'proposed/technical-debt/DEBT-0001-ddl-nao-versionado.md')
+    writeFileSync(join(base, 'proposed', 'index.md'), '# Catálogo\n')
+    const report = await runSync({ client: makeClient(api), baseDir: base })
+    expect(report.map((e) => e.id)).toEqual(['DEBT-0001'])
+  })
+})


### PR DESCRIPTION
## Spec ↔ GitHub Issue — Infraestrutura de sincronização (Fase 2)

Implementa a Fase 2 do ecossistema Spec-Driven + GitHub (ADR-0012, Blueprint v1.1-final).

### O que muda

- **`scripts/spec-github/`** — sync declarativo e **idempotente** Spec ↔ Issue: parser de Specs (`proposed/` + `archive/`), projeção do bloco `SPEC-PROJECTION` (título `[ID] Título`, labels `spec:<ID>` + tipo + `spec-driven`), cliente mínimo da GitHub REST API (sem dependências), backfill do campo `Issue: #N` no frontmatter.
- **Divergências nunca corrigidas silenciosamente** (D-12): Issue fechada com Spec ativa → reporta (CASO 3); Spec terminal com Issue aberta → reporta, **não fecha** (fechamento é ato explícito do workflow); corpo sem marcadores `SPEC-PROJECTION` → não sobrescreve; frontmatter com número errado → corrige para o Issue real encontrado por label.
- **`.mcp.json`** — servidor MCP oficial do GitHub (stdio via Docker) com `GITHUB_PERSONAL_ACCESS_TOKEN` vindo de `${GITHUB_TOKEN}`.
- **`templates/issue-projection.md` (T8)** — contrato canônico do corpo da Issue canônica; registrado na CONVENTIONS.
- **`package.json`** — `npm run spec:github:sync` / `spec:github:sync:dry`.

### Segurança

- O token NUNCA é versionado: scripts leem `GITHUB_TOKEN` do ambiente ou de `.env.github` (coberto pelo `.gitignore` via `.env*`).
- `git push` continua fora da allowlist permanente do Claude (D-13) — este push foi autorizado explicitamente pelo autor.

### Testes

- **20 testes** (vitest, API mockada): projeção/marcadores, parsing/backfill, criação + idempotência (2× não duplica), atualização preservando conteúdo humano, CASO 3, Spec terminal × Issue aberta, corpo manual, número divergente, dry-run sem token.
- eslint limpo; dry-run real: 14 specs detectadas, 0 divergências.

### Checklist

- [x] Infraestrutura conforme Blueprint aprovado (§20, §29 F2)
- [x] Testes verdes (20/20) e lint limpo
- [x] Sem mudança HIGH sem autorização
- [ ] Merge: aguardando aprovação humana do PR
