### PR TITLE
feat(project): sincronização Spec ↔ GitHub Project — Kanban do backlog (Fase 3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Os scripts do sync Spec↔GitHub exigem LF: line-endings CRLF quebram o transform do
+# vitest/esbuild em arquivos com shebang neste ambiente (Windows + core.autocrlf).
+scripts/spec-github/** text eol=lf

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "supabase:migrations:apply": "bash scripts/apply-supabase-migrations.sh",
     "cli": "node scripts/cli/index.js",
     "spec:github:sync": "node scripts/spec-github/sync.js",
-    "spec:github:sync:dry": "node scripts/spec-github/sync.js --dry-run"
+    "spec:github:sync:dry": "node scripts/spec-github/sync.js --dry-run",
+    "spec:project:sync": "node scripts/spec-github/project-sync.js",
+    "spec:project:sync:dry": "node scripts/spec-github/project-sync.js --dry-run"
   }
 }

--- a/scripts/spec-github/lib/env.js
+++ b/scripts/spec-github/lib/env.js
@@ -1,24 +1,32 @@
-// Carregamento do token do GitHub: variável de ambiente GITHUB_TOKEN ou arquivos locais de env
+// Carregamento de variáveis sensíveis do GitHub: variável de ambiente ou arquivos locais de env
 // (NÃO versionados — cobertos pelo .gitignore via `.env*`). Segurança: Blueprint v1.1-final §16.4.
 //
-// Ordem de leitura: `.env.github` (dedicado, preferido) → `.env.development` → `.env.production`
-// (locais onde o autor armazenou o token em 2026-08-16 — aceitos como fallback).
+// Ordem de leitura: `.env.github` (dedicado, preferido) → `.env.development` → `.env.production`.
 
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const ENV_FILES = ['.env.github', '.env.development', '.env.production']
 
-export function loadToken(repoRoot) {
-  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+export function loadVar(name, repoRoot) {
+  if (process.env[name]) return process.env[name]
 
-  for (const name of ENV_FILES) {
-    const envFile = join(repoRoot, name)
+  for (const fileName of ENV_FILES) {
+    const envFile = join(repoRoot, fileName)
     if (!existsSync(envFile)) continue
     for (const line of readFileSync(envFile, 'utf8').split(/\r?\n/)) {
-      const match = line.match(/^GITHUB_TOKEN\s*=\s*(.+)$/)
+      const match = line.match(new RegExp(`^${name}\\s*=\\s*(.+)$`))
       if (match && match[1].trim()) return match[1].trim()
     }
   }
   return null
+}
+
+export function loadToken(repoRoot) {
+  return loadVar('GITHUB_TOKEN', repoRoot)
+}
+
+/** Token para Projects v2: GITHUB_PROJECTS_TOKEN dedicado, com fallback no GITHUB_TOKEN. */
+export function loadProjectsToken(repoRoot) {
+  return loadVar('GITHUB_PROJECTS_TOKEN', repoRoot) ?? loadToken(repoRoot)
 }

--- a/scripts/spec-github/lib/graphql.js
+++ b/scripts/spec-github/lib/graphql.js
@@ -1,0 +1,33 @@
+// Cliente mínimo da GitHub GraphQL API (Projects v2), sem dependências externas.
+// Transporte injetável (testes usam mock). Erros GraphQL viram exceção explícita.
+
+export class GraphQLError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'GraphQLError'
+  }
+}
+
+export class GraphQLClient {
+  constructor({ token, fetchImpl = globalThis.fetch, endpoint = 'https://api.github.com/graphql' }) {
+    this.token = token
+    this.fetchImpl = fetchImpl
+    this.endpoint = endpoint
+  }
+
+  async query(query, variables = {}) {
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
+    })
+    const json = await response.json()
+    if (json.errors && json.errors.length > 0) {
+      throw new GraphQLError(json.errors.map((e) => `${e.type ?? 'ERROR'} ${e.message}`).join('; '))
+    }
+    return json.data
+  }
+}

--- a/scripts/spec-github/lib/project-mapping.js
+++ b/scripts/spec-github/lib/project-mapping.js
@@ -1,0 +1,42 @@
+// Mapeamento Spec Status → Project Status e opções dos campos do Project.
+// Contrato: Blueprint v1.1-final §10.2 e CONVENTIONS §18.4.
+
+export const STATUS_OPTIONS = [
+  { name: 'Backlog', color: 'GRAY' },
+  { name: 'Aprovado', color: 'BLUE' },
+  { name: 'Em andamento', color: 'YELLOW' },
+  { name: 'Bloqueado', color: 'RED' },
+  { name: 'Concluído', color: 'GREEN' },
+  { name: 'Encerrado', color: 'PURPLE' },
+]
+
+export const PRIORITY_OPTIONS = [
+  { name: 'Alta', color: 'RED' },
+  { name: 'Média', color: 'YELLOW' },
+  { name: 'Baixa', color: 'GRAY' },
+]
+
+export const DEFAULT_PRIORITY = 'Média'
+
+export const PROJECT_TITLE = 'MeuFenil — Spec-Driven Backlog'
+export const STATUS_FIELD = 'Status'
+export const PRIORITY_FIELD = 'Priority'
+
+/** Spec Status → Project Status (null = fora do mapeamento). */
+export function projectStatus(specStatus) {
+  switch (specStatus) {
+    case 'PROPOSED':
+      return 'Backlog'
+    case 'ACCEPTED':
+      return 'Aprovado'
+    case 'IMPLEMENTATION':
+      return 'Em andamento'
+    case 'IMPLEMENTED':
+      return 'Concluído'
+    case 'REJECTED':
+    case 'SUPERSEDED':
+      return 'Encerrado'
+    default:
+      return null
+  }
+}

--- a/scripts/spec-github/lib/project-mapping.js
+++ b/scripts/spec-github/lib/project-mapping.js
@@ -2,18 +2,21 @@
 // Contrato: Blueprint v1.1-final §10.2 e CONVENTIONS §18.4.
 
 export const STATUS_OPTIONS = [
-  { name: 'Backlog', color: 'GRAY' },
-  { name: 'Aprovado', color: 'BLUE' },
-  { name: 'Em andamento', color: 'YELLOW' },
-  { name: 'Bloqueado', color: 'RED' },
-  { name: 'Concluído', color: 'GREEN' },
-  { name: 'Encerrado', color: 'PURPLE' },
+  { name: 'Backlog', color: 'GRAY', description: 'Proposta aguardando decisão' },
+  { name: 'Aprovado', color: 'BLUE', description: 'Decisão humana registrada na Spec' },
+  { name: 'Em andamento', color: 'YELLOW', description: 'Em implementação (work branch)' },
+  { name: 'Bloqueado', color: 'RED', description: 'Override operacional — razão no Issue' },
+  { name: 'Concluído', color: 'GREEN', description: 'Implementado e validado' },
+  { name: 'Encerrado', color: 'PURPLE', description: 'Estado terminal (REJECTED/SUPERSEDED)' },
 ]
 
+/** Opções do campo Status que o GitHub pré-cria em Projects v2 novos. */
+export const DEFAULT_STATUS_OPTIONS = ['Todo', 'In Progress', 'Done']
+
 export const PRIORITY_OPTIONS = [
-  { name: 'Alta', color: 'RED' },
-  { name: 'Média', color: 'YELLOW' },
-  { name: 'Baixa', color: 'GRAY' },
+  { name: 'Alta', color: 'RED', description: 'Prioridade alta' },
+  { name: 'Média', color: 'YELLOW', description: 'Prioridade média' },
+  { name: 'Baixa', color: 'GRAY', description: 'Prioridade baixa' },
 ]
 
 export const DEFAULT_PRIORITY = 'Média'
@@ -21,6 +24,7 @@ export const DEFAULT_PRIORITY = 'Média'
 export const PROJECT_TITLE = 'MeuFenil — Spec-Driven Backlog'
 export const STATUS_FIELD = 'Status'
 export const PRIORITY_FIELD = 'Priority'
+export const KANBAN_VIEW_NAME = 'Kanban'
 
 /** Spec Status → Project Status (null = fora do mapeamento). */
 export function projectStatus(specStatus) {

--- a/scripts/spec-github/lib/project-mapping.test.js
+++ b/scripts/spec-github/lib/project-mapping.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PRIORITY,
+  PRIORITY_FIELD,
+  PRIORITY_OPTIONS,
+  PROJECT_TITLE,
+  STATUS_FIELD,
+  STATUS_OPTIONS,
+  projectStatus,
+} from './project-mapping.js'
+
+describe('project-mapping', () => {
+  it('mapeia Spec Status → Project Status (CONVENTIONS §18.4)', () => {
+    expect(projectStatus('PROPOSED')).toBe('Backlog')
+    expect(projectStatus('ACCEPTED')).toBe('Aprovado')
+    expect(projectStatus('IMPLEMENTATION')).toBe('Em andamento')
+    expect(projectStatus('IMPLEMENTED')).toBe('Concluído')
+    expect(projectStatus('REJECTED')).toBe('Encerrado')
+    expect(projectStatus('SUPERSEDED')).toBe('Encerrado')
+  })
+
+  it('retorna null para estados fora do vocabulário (Bloqueado é override do Project, não da Spec)', () => {
+    expect(projectStatus('BLOQUEADO')).toBeNull()
+    expect(projectStatus('UNKNOWN')).toBeNull()
+    expect(projectStatus(null)).toBeNull()
+  })
+
+  it('define as opções canônicas dos campos', () => {
+    expect(STATUS_OPTIONS.map((o) => o.name)).toEqual([
+      'Backlog',
+      'Aprovado',
+      'Em andamento',
+      'Bloqueado',
+      'Concluído',
+      'Encerrado',
+    ])
+    expect(PRIORITY_OPTIONS.map((o) => o.name)).toEqual(['Alta', 'Média', 'Baixa'])
+    expect(DEFAULT_PRIORITY).toBe('Média')
+    expect(STATUS_FIELD).toBe('Status')
+    expect(PRIORITY_FIELD).toBe('Priority')
+    expect(PROJECT_TITLE).toBe('MeuFenil — Spec-Driven Backlog')
+  })
+})

--- a/scripts/spec-github/project-sync.js
+++ b/scripts/spec-github/project-sync.js
@@ -17,6 +17,8 @@ import { GraphQLClient, GraphQLError } from './lib/graphql.js'
 import { loadProjectsToken } from './lib/env.js'
 import {
   DEFAULT_PRIORITY,
+  DEFAULT_STATUS_OPTIONS,
+  KANBAN_VIEW_NAME,
   PRIORITY_FIELD,
   PRIORITY_OPTIONS,
   PROJECT_TITLE,
@@ -43,10 +45,14 @@ const QUERIES = {
   createProject: `mutation($input: CreateProjectV2Input!) { createProjectV2(input: $input) { projectV2 { id number title } } }`,
   linkRepository: `mutation($input: LinkProjectV2ToRepositoryInput!) { linkProjectV2ToRepository(input: $input) { repository { name } } }`,
   fields: `query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2Field { id name dataType } ... on ProjectV2SingleSelectField { id name dataType options { id name } } } } } } }`,
-  createField: `mutation($input: CreateProjectV2FieldInput!) { createProjectV2Field(input: $input) { projectV2Field { id name } } }`,
+  createField: `mutation($input: CreateProjectV2FieldInput!) { createProjectV2Field(input: $input) { projectV2Field { ... on ProjectV2Field { id name } ... on ProjectV2SingleSelectField { id name } } } }`,
+  updateField: `mutation($input: UpdateProjectV2FieldInput!) { updateProjectV2Field(input: $input) { projectV2Field { ... on ProjectV2Field { id name } ... on ProjectV2SingleSelectField { id name } } } }`,
   items: `query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { items(first: 100) { nodes { id content { ... on Issue { id number } } status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } priority: fieldValueByName(name: "Priority") { ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } } } } } }`,
   addItem: `mutation($input: AddProjectV2ItemByIdInput!) { addProjectV2ItemById(input: $input) { item { id } } }`,
   setField: `mutation($input: UpdateProjectV2ItemFieldValueInput!) { updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } } }`,
+  views: `query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { views(first: 20) { nodes { id name layout groupBy(first: 10) { nodes { name } } } } } } }`,
+  updateView: `mutation($input: UpdateProjectV2ViewInput!) { updateProjectV2View(input: $input) { projectV2View { id name layout } } }`,
+  createView: `mutation($input: CreateProjectV2ViewInput!) { createProjectV2View(input: $input) { projectV2View { id name layout } } }`,
 }
 
 function findProject(viewerData, title) {
@@ -89,7 +95,7 @@ export async function runProjectSync({ token, rest, gql, baseDir, dryRun = false
 
   // 1. Localizar (ou criar) o Project pelo título — idempotente.
   const viewer = await gql.query(QUERIES.viewer)
-  let project = findProject(viewer, PROJECT_TITLE)
+  let project = findProject(viewer.viewer, PROJECT_TITLE)
   if (!project) {
     const created = await gql.query(QUERIES.createProject, {
       input: { ownerId: viewer.viewer.id, title: PROJECT_TITLE },
@@ -110,37 +116,48 @@ export async function runProjectSync({ token, rest, gql, baseDir, dryRun = false
   }
 
   // 3. Garantir campos Status e Priority (idempotente).
+  //    Projects v2 novos já vêm com um campo Status built-in (Todo/In Progress/Done) que a
+  //    GraphQL não deixa deletar nem criar por cima. updateProjectV2Field aceita built-ins,
+  //    então o padrão intacto é atualizado com as opções do Blueprint §10.2 (a Board view
+  //    padrão agrupa por esse campo). Campo personalizado por humano ou com item usando
+  //    valor nunca é alterado (a divergência é reportada no passo 4). Obs.: a API exige
+  //    `description` em cada opção single-select.
+  const createSingleSelect = async (name, options) => {
+    await gql.query(QUERIES.createField, {
+      input: { projectId: project.id, name, dataType: 'SINGLE_SELECT', singleSelectOptions: options },
+    })
+    fields = await gql.query(QUERIES.fields, { projectId: project.id })
+    return findField(fields, name)
+  }
+
+  const values = await gql.query(QUERIES.items, { projectId: project.id })
+  const currentItems = values?.node?.items?.nodes ?? []
   let fields = await gql.query(QUERIES.fields, { projectId: project.id })
   let statusField = findField(fields, STATUS_FIELD)
+
   if (!statusField) {
-    await gql.query(QUERIES.createField, {
-      input: {
-        projectId: project.id,
-        name: STATUS_FIELD,
-        dataType: 'SINGLE_SELECT',
-        singleSelectOptions: STATUS_OPTIONS,
-      },
-    })
-    fields = await gql.query(QUERIES.fields, { projectId: project.id })
-    statusField = findField(fields, STATUS_FIELD)
+    statusField = await createSingleSelect(STATUS_FIELD, STATUS_OPTIONS)
+  } else if (!statusField.options?.some((o) => STATUS_OPTIONS.some((s) => s.name === o.name))) {
+    const names = (statusField.options ?? []).map((o) => o.name)
+    const isGitHubDefault =
+      names.length === DEFAULT_STATUS_OPTIONS.length &&
+      DEFAULT_STATUS_OPTIONS.every((n) => names.includes(n))
+    const itemsUseStatus = currentItems.some((i) => i.status?.name)
+    if (isGitHubDefault && !itemsUseStatus) {
+      await gql.query(QUERIES.updateField, {
+        input: { fieldId: statusField.id, name: STATUS_FIELD, singleSelectOptions: STATUS_OPTIONS },
+      })
+      fields = await gql.query(QUERIES.fields, { projectId: project.id })
+      statusField = findField(fields, STATUS_FIELD)
+    }
   }
+
   let priorityField = findField(fields, PRIORITY_FIELD)
   if (!priorityField) {
-    await gql.query(QUERIES.createField, {
-      input: {
-        projectId: project.id,
-        name: PRIORITY_FIELD,
-        dataType: 'SINGLE_SELECT',
-        singleSelectOptions: PRIORITY_OPTIONS,
-      },
-    })
-    fields = await gql.query(QUERIES.fields, { projectId: project.id })
-    priorityField = findField(fields, PRIORITY_FIELD)
+    priorityField = await createSingleSelect(PRIORITY_FIELD, PRIORITY_OPTIONS)
   }
 
   // 4. Items: adicionar Issues canônicas e aplicar Status/Priority derivados.
-  const values = await gql.query(QUERIES.items, { projectId: project.id })
-  const currentItems = values?.node?.items?.nodes ?? []
 
   for (const spec of specs) {
     const entry = { id: spec.id, issue: spec.issue, action: 'ok', divergences: [] }
@@ -200,6 +217,26 @@ export async function runProjectSync({ token, rest, gql, baseDir, dryRun = false
     }
 
     report.push(entry)
+  }
+
+  // 5. View Kanban (idempotente): garantir BOARD_LAYOUT com nome "Kanban".
+  //    O groupBy (colunas por Status) não é exposto pela GraphQL — configurar uma única
+  //    vez na UI ("Group by Status"); a nota abaixo lembra até isso ser feito.
+  const viewsData = await gql.query(QUERIES.views, { projectId: project.id })
+  const views = viewsData?.node?.views?.nodes ?? []
+  const kanban = views.find((v) => v.name === KANBAN_VIEW_NAME) ?? views[0] ?? null
+  const groupedByStatus = Boolean(kanban?.groupBy?.nodes?.some((g) => g.name === STATUS_FIELD))
+  if (!kanban) {
+    await gql.query(QUERIES.createView, {
+      input: { projectId: project.id, name: KANBAN_VIEW_NAME, layout: 'BOARD_LAYOUT' },
+    })
+  } else if (kanban.name !== KANBAN_VIEW_NAME || kanban.layout !== 'BOARD_LAYOUT') {
+    await gql.query(QUERIES.updateView, {
+      input: { viewId: kanban.id, name: KANBAN_VIEW_NAME, layout: 'BOARD_LAYOUT' },
+    })
+  }
+  if (!groupedByStatus) {
+    console.log('NOTA: view "Kanban" sem groupBy Status — a GraphQL não expõe groupBy; configure "Group by Status" na UI.')
   }
 
   return report

--- a/scripts/spec-github/project-sync.js
+++ b/scripts/spec-github/project-sync.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// Sync GitHub Project ← Specs (Fase 3 — Blueprint v1.1-final §10/§21).
+//
+// IDEMPOTENTE: executar duas vezes não duplica items nem regrava valores idênticos.
+// O Project é DERIVADO das Specs: Status = f(Spec Status); Priority tem default (Média)
+// e nunca é sobrescrito quando já definido. O item do Project É a Issue canônica.
+//
+// Uso:
+//   node scripts/spec-github/project-sync.js                 # requer GITHUB_PROJECTS_TOKEN ou GITHUB_TOKEN
+//   node scripts/spec-github/project-sync.js --dry-run       # pré-visual local
+
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+import { listSpecs } from './lib/specs.js'
+import { GitHubClient } from './lib/github.js'
+import { GraphQLClient, GraphQLError } from './lib/graphql.js'
+import { loadProjectsToken } from './lib/env.js'
+import {
+  DEFAULT_PRIORITY,
+  PRIORITY_FIELD,
+  PRIORITY_OPTIONS,
+  PROJECT_TITLE,
+  STATUS_FIELD,
+  STATUS_OPTIONS,
+  projectStatus,
+} from './lib/project-mapping.js'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+function parseArgs(argv) {
+  const args = { dryRun: false, baseDir: join(REPO_ROOT, '.ai', 'specs'), repo: 'lucasmm96/meufenil' }
+  for (const arg of argv) {
+    if (arg === '--dry-run') args.dryRun = true
+    else if (arg.startsWith('--base-dir=')) args.baseDir = resolve(arg.slice('--base-dir='.length))
+    else if (arg.startsWith('--repo=')) args.repo = arg.slice('--repo='.length)
+  }
+  return args
+}
+
+const QUERIES = {
+  viewer: `query { viewer { id login projectsV2(first: 50) { nodes { id title number } } } }`,
+  repositoryId: `query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id } }`,
+  createProject: `mutation($input: CreateProjectV2Input!) { createProjectV2(input: $input) { projectV2 { id number title } } }`,
+  linkRepository: `mutation($input: LinkProjectV2ToRepositoryInput!) { linkProjectV2ToRepository(input: $input) { repository { name } } }`,
+  fields: `query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { fields(first: 50) { nodes { ... on ProjectV2Field { id name dataType } ... on ProjectV2SingleSelectField { id name dataType options { id name } } } } } } }`,
+  createField: `mutation($input: CreateProjectV2FieldInput!) { createProjectV2Field(input: $input) { projectV2Field { id name } } }`,
+  items: `query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { items(first: 100) { nodes { id content { ... on Issue { id number } } status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } priority: fieldValueByName(name: "Priority") { ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } } } } } }`,
+  addItem: `mutation($input: AddProjectV2ItemByIdInput!) { addProjectV2ItemById(input: $input) { item { id } } }`,
+  setField: `mutation($input: UpdateProjectV2ItemFieldValueInput!) { updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } } }`,
+}
+
+function findProject(viewerData, title) {
+  const nodes = viewerData?.projectsV2?.nodes ?? []
+  return nodes.find((p) => p.title === title) ?? null
+}
+
+function findField(fieldsData, name) {
+  const nodes = fieldsData?.node?.fields?.nodes ?? []
+  const field = nodes.find((f) => f.name === name)
+  if (!field) return null
+  return { id: field.id, options: field.options ?? null }
+}
+
+function findItem(itemsData, contentId) {
+  const nodes = itemsData?.node?.items?.nodes ?? []
+  return nodes.find((i) => i.content?.id === contentId) ?? null
+}
+
+/**
+ * Sincroniza o Project com as Specs. Retorna relatório por Spec.
+ * @param {object} opts { token, rest, gql, baseDir, dryRun }
+ */
+export async function runProjectSync({ token, rest, gql, baseDir, dryRun = false }) {
+  const specs = listSpecs(baseDir).filter((s) => s.issue !== null)
+  const report = []
+
+  if (dryRun || !token) {
+    for (const spec of specs) {
+      const status = projectStatus(spec.status)
+      report.push({
+        id: spec.id,
+        issue: spec.issue,
+        action: status ? `local-preview (Status → ${status})` : 'local-preview (sem mapeamento)',
+        divergences: [],
+      })
+    }
+    return report
+  }
+
+  // 1. Localizar (ou criar) o Project pelo título — idempotente.
+  const viewer = await gql.query(QUERIES.viewer)
+  let project = findProject(viewer, PROJECT_TITLE)
+  if (!project) {
+    const created = await gql.query(QUERIES.createProject, {
+      input: { ownerId: viewer.viewer.id, title: PROJECT_TITLE },
+    })
+    project = created.createProjectV2.projectV2
+  }
+
+  // 2. Linkar ao repositório (idempotente: erro de "already linked" é ignorado).
+  try {
+    const repoData = await gql.query(QUERIES.repositoryId, { owner: rest.owner, name: rest.repo })
+    const repositoryId = repoData.repository?.id
+    if (repositoryId) {
+      await gql.query(QUERIES.linkRepository, { input: { projectId: project.id, repositoryId } })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!/already|linked/i.test(message)) throw error
+  }
+
+  // 3. Garantir campos Status e Priority (idempotente).
+  let fields = await gql.query(QUERIES.fields, { projectId: project.id })
+  let statusField = findField(fields, STATUS_FIELD)
+  if (!statusField) {
+    await gql.query(QUERIES.createField, {
+      input: {
+        projectId: project.id,
+        name: STATUS_FIELD,
+        dataType: 'SINGLE_SELECT',
+        singleSelectOptions: STATUS_OPTIONS,
+      },
+    })
+    fields = await gql.query(QUERIES.fields, { projectId: project.id })
+    statusField = findField(fields, STATUS_FIELD)
+  }
+  let priorityField = findField(fields, PRIORITY_FIELD)
+  if (!priorityField) {
+    await gql.query(QUERIES.createField, {
+      input: {
+        projectId: project.id,
+        name: PRIORITY_FIELD,
+        dataType: 'SINGLE_SELECT',
+        singleSelectOptions: PRIORITY_OPTIONS,
+      },
+    })
+    fields = await gql.query(QUERIES.fields, { projectId: project.id })
+    priorityField = findField(fields, PRIORITY_FIELD)
+  }
+
+  // 4. Items: adicionar Issues canônicas e aplicar Status/Priority derivados.
+  const values = await gql.query(QUERIES.items, { projectId: project.id })
+  const currentItems = values?.node?.items?.nodes ?? []
+
+  for (const spec of specs) {
+    const entry = { id: spec.id, issue: spec.issue, action: 'ok', divergences: [] }
+    const issueData = await rest.getIssue(spec.issue)
+    if (!issueData) {
+      entry.divergences.push(`Issue #${spec.issue} não encontrada no GitHub`)
+      entry.action = 'skipped'
+      report.push(entry)
+      continue
+    }
+    const contentId = issueData.node_id
+
+    let item = findItem({ node: { items: { nodes: currentItems } } }, contentId)
+    if (!item) {
+      const added = await gql.query(QUERIES.addItem, { input: { projectId: project.id, contentId } })
+      item = { id: added.addProjectV2ItemById.item.id }
+      entry.action = 'item-added'
+    }
+
+    const current = currentItems.find((i) => i.content?.id === contentId) ?? null
+    const currentStatus = current?.status?.name ?? null
+    const currentPriority = current?.priority?.name ?? null
+    const desiredStatus = projectStatus(spec.status)
+
+    if (desiredStatus && currentStatus !== desiredStatus) {
+      const option = statusField.options?.find((o) => o.name === desiredStatus)
+      if (!option) {
+        entry.divergences.push(`opção "${desiredStatus}" ausente no campo Status`)
+      } else {
+        await gql.query(QUERIES.setField, {
+          input: {
+            projectId: project.id,
+            itemId: item.id,
+            fieldId: statusField.id,
+            value: { singleSelectOptionId: option.id },
+          },
+        })
+        entry.action = entry.action === 'item-added' ? 'item-added + status' : 'status-set'
+      }
+    }
+
+    if (!currentPriority) {
+      const option = priorityField?.options?.find((o) => o.name === DEFAULT_PRIORITY)
+      if (!option) {
+        entry.divergences.push(`opção "${DEFAULT_PRIORITY}" ausente no campo Priority`)
+      } else {
+        await gql.query(QUERIES.setField, {
+          input: {
+            projectId: project.id,
+            itemId: item.id,
+            fieldId: priorityField.id,
+            value: { singleSelectOptionId: option.id },
+          },
+        })
+        if (entry.action === 'ok') entry.action = 'priority-default'
+      }
+    }
+
+    report.push(entry)
+  }
+
+  return report
+}
+
+function printReport(report, dryRun) {
+  console.log(`\nProject sync${dryRun ? ' (DRY-RUN)' : ''} — ${report.length} specs com Issue\n`)
+  for (const entry of report) {
+    const line = [
+      entry.id.padEnd(12),
+      entry.issue ? `#${String(entry.issue).padEnd(5)}` : '      ',
+      String(entry.action).padEnd(28),
+    ].join('  ')
+    console.log(line)
+    for (const d of entry.divergences) console.log(`  ⚠ ${d}`)
+  }
+  const divergences = report.reduce((n, e) => n + e.divergences.length, 0)
+  console.log(`\nDivergências: ${divergences}`)
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2))
+  const [owner, repo] = args.repo.split('/')
+  const token = loadProjectsToken(REPO_ROOT)
+  if (!token && !args.dryRun) {
+    console.error('GITHUB_PROJECTS_TOKEN/GITHUB_TOKEN ausente — defina em .env.github (não versionado).')
+    process.exit(1)
+  }
+  try {
+    const gql = token ? new GraphQLClient({ token }) : null
+    const rest = token ? new GitHubClient({ token, owner, repo }) : null
+    const report = await runProjectSync({ token, rest, gql, baseDir: args.baseDir, dryRun: args.dryRun })
+    printReport(report, args.dryRun)
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      console.error(`Falha GraphQL: ${error.message}`)
+    } else {
+      console.error(error)
+    }
+    process.exit(1)
+  }
+}

--- a/scripts/spec-github/project-sync.test.js
+++ b/scripts/spec-github/project-sync.test.js
@@ -18,7 +18,7 @@ function copyFixture(tempBase, rel) {
 
 /** Fake GraphQL (Projects v2) com estado em memória. */
 function createFakeGql() {
-  const state = { projects: [], fields: [], items: [], calls: [] }
+  const state = { projects: [], fields: [], items: [], views: [], calls: [] }
   const json = (payload) => ({ ok: true, json: async () => payload })
 
   const transport = async (endpoint, init) => {
@@ -37,6 +37,17 @@ function createFakeGql() {
       state.fields.push(field)
       return json({ data: { createProjectV2Field: { projectV2Field: field } } })
     }
+    if (query.includes('updateProjectV2Field')) {
+      const field = state.fields.find((f) => f.id === variables.input.fieldId)
+      field.name = variables.input.name
+      field.options = (variables.input.singleSelectOptions ?? []).map((o, i) => ({ id: `O_${o.name}_${i}`, name: o.name }))
+      return json({ data: { updateProjectV2Field: { projectV2Field: field } } })
+    }
+    if (query.includes('createProjectV2View')) {
+      const view = { id: 'PVTV_1', name: variables.input.name, layout: variables.input.layout, groupBy: { nodes: [] } }
+      state.views.push(view)
+      return json({ data: { createProjectV2View: { projectV2View: view } } })
+    }
     if (query.includes('createProjectV2')) {
       const project = { id: 'PVT_1', number: 1, title: variables.input.title }
       state.projects.push(project)
@@ -53,6 +64,15 @@ function createFakeGql() {
     }
     if (query.includes('fieldValueByName')) {
       return json({ data: { node: { items: { nodes: state.items } } } })
+    }
+    if (query.includes('views(first: 20)')) {
+      return json({ data: { node: { views: { nodes: state.views } } } })
+    }
+    if (query.includes('updateProjectV2View')) {
+      const view = state.views.find((v) => v.id === variables.input.viewId)
+      view.name = variables.input.name
+      view.layout = variables.input.layout
+      return json({ data: { updateProjectV2View: { projectV2View: view } } })
     }
     if (query.includes('addProjectV2ItemById')) {
       const item = {
@@ -151,6 +171,136 @@ describe('project-sync', () => {
     expect(actions.some((a) => a.includes('item-added'))).toBe(true)
   })
 
+  /** Project novo como o GitHub entrega: campo Status padrão (Todo/In Progress/Done). */
+  function seedGitHubDefaultStatus(gqlApi) {
+    gqlApi.state.projects.push({ id: 'PVT_1', number: 1, title: 'MeuFenil — Spec-Driven Backlog' })
+    gqlApi.state.fields.push({
+      id: 'F_Status',
+      name: 'Status',
+      options: [
+        { id: 'O_Todo', name: 'Todo' },
+        { id: 'O_IP', name: 'In Progress' },
+        { id: 'O_Done', name: 'Done' },
+      ],
+    })
+  }
+
+  it('substitui o Status padrão do GitHub pelo Status custom do Blueprint §10.2', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    seedGitHubDefaultStatus(gqlApi)
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const updates = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2Field'))
+    expect(updates.length).toBe(1)
+    expect(gqlApi.state.calls.filter((c) => c.query.includes('createProjectV2(')).length).toBe(0)
+    const statusField = gqlApi.state.fields.find((f) => f.name === 'Status')
+    expect(statusField.options.map((o) => o.name)).toEqual([
+      'Backlog',
+      'Aprovado',
+      'Em andamento',
+      'Bloqueado',
+      'Concluído',
+      'Encerrado',
+    ])
+    const testItem = gqlApi.state.items.find((i) => i.content.id === 'N_42')
+    expect(testItem.status.name).toBe('Backlog')
+  })
+
+  it('não deleta o Status padrão quando há item usando o campo', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    seedGitHubDefaultStatus(gqlApi)
+    gqlApi.state.items.push({
+      id: 'PVTI_N_42',
+      content: { id: 'N_42', number: 42 },
+      status: { name: 'Todo', optionId: 'O_Todo' },
+      priority: null,
+    })
+
+    const report = await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const updates = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2Field'))
+    expect(updates.length).toBe(0)
+    const entry = report.find((e) => e.id === 'TEST-0002')
+    expect(entry.divergences.join(' ')).toContain('ausente no campo Status')
+  })
+
+  it('não altera Status com opções personalizadas por humano', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    gqlApi.state.projects.push({ id: 'PVT_1', number: 1, title: 'MeuFenil — Spec-Driven Backlog' })
+    gqlApi.state.fields.push({
+      id: 'F_Status',
+      name: 'Status',
+      options: [{ id: 'O_Custom', name: 'Custom' }],
+    })
+
+    const report = await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const updates = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2Field'))
+    expect(updates.length).toBe(0)
+    const entry = report.find((e) => e.id === 'TEST-0002')
+    expect(entry.divergences.join(' ')).toContain('ausente no campo Status')
+  })
+
+  it('atualiza a view padrão TABLE para Kanban BOARD', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    gqlApi.state.projects.push({ id: 'PVT_1', number: 1, title: 'MeuFenil — Spec-Driven Backlog' })
+    gqlApi.state.views.push({ id: 'PVTV_1', name: 'View 1', layout: 'TABLE_LAYOUT', groupBy: { nodes: [] } })
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const updates = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2View'))
+    expect(updates.length).toBe(1)
+    expect(gqlApi.state.views[0]).toMatchObject({ name: 'Kanban', layout: 'BOARD_LAYOUT' })
+  })
+
+  it('cria view Kanban quando o Project não tem views', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    gqlApi.state.projects.push({ id: 'PVT_1', number: 1, title: 'MeuFenil — Spec-Driven Backlog' })
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const creates = gqlApi.state.calls.filter((c) => c.query.includes('createProjectV2View'))
+    expect(creates.length).toBe(1)
+    expect(gqlApi.state.views[0]).toMatchObject({ name: 'Kanban', layout: 'BOARD_LAYOUT' })
+  })
+
+  it('não altera view Kanban já configurada com groupBy Status', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+    gqlApi.state.projects.push({ id: 'PVT_1', number: 1, title: 'MeuFenil — Spec-Driven Backlog' })
+    gqlApi.state.views.push({
+      id: 'PVTV_1',
+      name: 'Kanban',
+      layout: 'BOARD_LAYOUT',
+      groupBy: { nodes: [{ name: 'Status' }] },
+    })
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const mutations = gqlApi.state.calls.filter(
+      (c) => c.query.includes('updateProjectV2View') || c.query.includes('createProjectV2View'),
+    )
+    expect(mutations.length).toBe(0)
+  })
+
   it('é idempotente: segunda execução não adiciona items nem regrava valores', async () => {
     const gqlApi = createFakeGql()
     const base = tempBase()
@@ -168,6 +318,8 @@ describe('project-sync', () => {
     expect(addsAfterFirst).toBe(2)
     expect(addsAfterSecond).toBe(2)
     expect(setsAfterSecond).toBe(setsAfterFirst)
+    expect(gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2Field')).length).toBe(0)
+    expect(gqlApi.state.projects.length).toBe(1)
     expect(gqlApi.state.items.length).toBe(2)
     expect(second.every((e) => e.action === 'ok')).toBe(true)
   })

--- a/scripts/spec-github/project-sync.test.js
+++ b/scripts/spec-github/project-sync.test.js
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runProjectSync } from './project-sync.js'
+import { GitHubClient } from './lib/github.js'
+import { GraphQLClient } from './lib/graphql.js'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'specs')
+
+function copyFixture(tempBase, rel) {
+  const dest = join(tempBase, rel)
+  mkdirSync(dirname(dest), { recursive: true })
+  copyFileSync(join(FIXTURES, rel), dest)
+  return dest
+}
+
+/** Fake GraphQL (Projects v2) com estado em memória. */
+function createFakeGql() {
+  const state = { projects: [], fields: [], items: [], calls: [] }
+  const json = (payload) => ({ ok: true, json: async () => payload })
+
+  const transport = async (endpoint, init) => {
+    const { query, variables } = JSON.parse(init.body)
+    state.calls.push({ query, variables })
+
+    if (query.includes('projectsV2(first: 50)')) {
+      return json({ data: { viewer: { id: 'U_1', login: 'lucasmm96', projectsV2: { nodes: state.projects } } } })
+    }
+    if (query.includes('createProjectV2Field')) {
+      const field = {
+        id: `F_${variables.input.name}`,
+        name: variables.input.name,
+        options: (variables.input.singleSelectOptions ?? []).map((o, i) => ({ id: `O_${o.name}_${i}`, name: o.name })),
+      }
+      state.fields.push(field)
+      return json({ data: { createProjectV2Field: { projectV2Field: field } } })
+    }
+    if (query.includes('createProjectV2')) {
+      const project = { id: 'PVT_1', number: 1, title: variables.input.title }
+      state.projects.push(project)
+      return json({ data: { createProjectV2: { projectV2: project } } })
+    }
+    if (query.includes('repository(owner')) {
+      return json({ data: { repository: { id: 'R_1' } } })
+    }
+    if (query.includes('linkProjectV2ToRepository')) {
+      return json({ data: { linkProjectV2ToRepository: { repository: { name: 'meufenil' } } } })
+    }
+    if (query.includes('fields(first: 50)')) {
+      return json({ data: { node: { fields: { nodes: state.fields } } } })
+    }
+    if (query.includes('fieldValueByName')) {
+      return json({ data: { node: { items: { nodes: state.items } } } })
+    }
+    if (query.includes('addProjectV2ItemById')) {
+      const item = {
+        id: `PVTI_${variables.input.contentId}`,
+        content: { id: variables.input.contentId, number: null },
+        status: null,
+        priority: null,
+      }
+      state.items.push(item)
+      return json({ data: { addProjectV2ItemById: { item } } })
+    }
+    if (query.includes('updateProjectV2ItemFieldValue')) {
+      const item = state.items.find((i) => i.id === variables.input.itemId)
+      const field = state.fields.find((f) => f.id === variables.input.fieldId)
+      const option = field.options.find((o) => o.id === variables.input.value.singleSelectOptionId)
+      if (field.name === 'Status') item.status = { name: option.name, optionId: option.id }
+      else item.priority = { name: option.name, optionId: option.id }
+      return json({ data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: item.id } } } })
+    }
+    throw new Error(`query não reconhecida: ${query.slice(0, 60)}`)
+  }
+
+  return { state, transport }
+}
+
+/** Fake REST que devolve node_id por número de Issue. */
+function createFakeRest(nodeIds) {
+  const calls = []
+  const fetchImpl = async (url) => {
+    calls.push({ url: String(url) })
+    const number = Number(new URL(url).pathname.split('/').pop())
+    if (nodeIds[number]) {
+      return { status: 200, ok: true, json: async () => ({ number, node_id: nodeIds[number] }) }
+    }
+    return { status: 404, ok: false, json: async () => ({ message: 'Not Found' }) }
+  }
+  return { calls, fetchImpl }
+}
+
+function makeClient(gqlApi, nodeIds) {
+  const rest = new GitHubClient({
+    token: 'test-token',
+    owner: 'o',
+    repo: 'r',
+    fetchImpl: createFakeRest(nodeIds).fetchImpl,
+  })
+  const gql = new GraphQLClient({ token: 'test-token', fetchImpl: gqlApi.transport })
+  return { rest, gql }
+}
+
+describe('project-sync', () => {
+  let tempDirs = []
+
+  beforeEach(() => {
+    tempDirs = []
+  })
+
+  afterEach(() => {
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+  })
+
+  function tempBase() {
+    const dir = mkdtempSync(join(tmpdir(), 'project-sync-'))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  const NODE_IDS = { 42: 'N_42', 7: 'N_7' }
+
+  function seedFixtures(base) {
+    copyFixture(base, 'proposed/testing/TEST-0002-suites-seguranca-policies.md')
+    copyFixture(base, 'archive/implemented/technical-debt/DEBT-0004-reconciliar-templates.md')
+  }
+
+  it('cria Project, campos, items e aplica Status/Priority derivados', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+
+    const report = await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    expect(gqlApi.state.projects.length).toBe(1)
+    expect(gqlApi.state.projects[0].title).toBe('MeuFenil — Spec-Driven Backlog')
+    expect(gqlApi.state.fields.map((f) => f.name).sort()).toEqual(['Priority', 'Status'])
+    expect(gqlApi.state.items.length).toBe(2)
+
+    const testItem = gqlApi.state.items.find((i) => i.content.id === 'N_42')
+    const debtItem = gqlApi.state.items.find((i) => i.content.id === 'N_7')
+    expect(testItem.status.name).toBe('Backlog')
+    expect(testItem.priority.name).toBe('Média')
+    expect(debtItem.status.name).toBe('Concluído')
+    expect(debtItem.priority.name).toBe('Média')
+
+    const actions = report.map((e) => e.action)
+    expect(actions.some((a) => a.includes('item-added'))).toBe(true)
+  })
+
+  it('é idempotente: segunda execução não adiciona items nem regrava valores', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+    const addsAfterFirst = gqlApi.state.calls.filter((c) => c.query.includes('addProjectV2ItemById')).length
+    const setsAfterFirst = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2ItemFieldValue')).length
+
+    const second = await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+    const addsAfterSecond = gqlApi.state.calls.filter((c) => c.query.includes('addProjectV2ItemById')).length
+    const setsAfterSecond = gqlApi.state.calls.filter((c) => c.query.includes('updateProjectV2ItemFieldValue')).length
+
+    expect(addsAfterFirst).toBe(2)
+    expect(addsAfterSecond).toBe(2)
+    expect(setsAfterSecond).toBe(setsAfterFirst)
+    expect(gqlApi.state.items.length).toBe(2)
+    expect(second.every((e) => e.action === 'ok')).toBe(true)
+  })
+
+  it('não sobrescreve Priority já definida', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, NODE_IDS)
+
+    // Pré-existente: item com Priority Alta (definida por humano).
+    gqlApi.state.items.push({
+      id: 'PVTI_N_42',
+      content: { id: 'N_42', number: 42 },
+      status: { name: 'Backlog', optionId: 'O_Backlog_0' },
+      priority: { name: 'Alta', optionId: 'O_Alta_0' },
+    })
+
+    await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+
+    const testItem = gqlApi.state.items.find((i) => i.content.id === 'N_42')
+    expect(testItem.priority.name).toBe('Alta')
+  })
+
+  it('dry-run sem token: pré-visual local, sem transportes', async () => {
+    const base = tempBase()
+    seedFixtures(base)
+    const report = await runProjectSync({ token: null, rest: null, gql: null, baseDir: base, dryRun: true })
+    expect(report.length).toBe(2)
+    expect(report[0].action).toContain('local-preview')
+    expect(report.find((e) => e.id === 'DEBT-0004').action).toContain('Concluído')
+  })
+
+  it('Issue inexistente no GitHub → divergência e skip', async () => {
+    const gqlApi = createFakeGql()
+    const base = tempBase()
+    seedFixtures(base)
+    const { rest, gql } = makeClient(gqlApi, { 42: 'N_42' }) // #7 ausente
+
+    const report = await runProjectSync({ token: 'test-token', rest, gql, baseDir: base })
+    const entry = report.find((e) => e.id === 'DEBT-0004')
+    expect(entry.action).toBe('skipped')
+    expect(entry.divergences.join(' ')).toContain('não encontrada')
+  })
+})


### PR DESCRIPTION
## Spec ↔ GitHub Project — Project + Kanban do backlog (Fase 3)

Fase 3 do ecossistema Spec-Driven + GitHub (ADR-0012, Blueprint v1.1-final): infraestrutura do `project-sync` + primeira execução real validada.

### O que muda

- **`scripts/spec-github/project-sync.js`**: cria/encontra o Project "MeuFenil — Spec-Driven Backlog", linka ao repositório, garante os campos Status/Priority, adiciona as Issues canônicas como items e aplica Status derivado (`f(Spec Status)`) + Priority default (Média, nunca sobrescrita quando já definida).
- **`lib/graphql.js`**: cliente mínimo da GraphQL de Projects v2, sem dependências externas.
- **`lib/project-mapping.js`**: mapeamento Spec Status → Project Status (Blueprint §10.2) e opções dos campos.
- **`lib/env.js`**: `loadProjectsToken` (`GITHUB_PROJECTS_TOKEN` || `GITHUB_TOKEN`; `.env.github` preferido, nunca versionado).
- **`.gitattributes`**: `eol=lf` para `scripts/spec-github/**` (CRLF quebra o transform do vitest/esbuild em arquivos com shebang).

### Correções reveladas pela execução real (GraphQL de Projects v2)

- `createProjectV2Field`/`updateProjectV2Field` retornam a union `ProjectV2FieldConfiguration` — payload agora usa fragmentos inline;
- `ProjectV2SingleSelectFieldOptionInput` exige `description` em cada opção (todas as opções agora têm);
- o campo Status **built-in** não pode ser deletado ("Only custom fields can be deleted"), mas aceita `updateProjectV2Field` — o script substitui o padrão (Todo/In Progress/Done) pelas 6 opções do Blueprint §10.2, com guardas: nunca altera campo personalizado por humano nem campo com item usando valor (divergência reportada nesses casos);
- **`findProject` recebia o objeto `data` inteiro em vez de `data.viewer`** — o Project existente nunca era encontrado e cada execução criava um novo (4 duplicados reais). Corrigido + teste de regressão (`projects.length` após 2 execuções). Os 3 duplicados vazios foram removidos com autorização do autor;
- **View Kanban (UNKNOWN do Blueprint resolvido)**: a GraphQL seta nome/layout (`BOARD_LAYOUT`) mas **não expõe `groupBy`** — o script garante a view "Kanban" e imprime nota até o "Group by Status" ser configurado uma única vez na UI.

### Verificação em execução real

- 1ª execução real: 15 items criados, Status derivado (10 Backlog + 5 Concluído), 0 divergências.
- Execuções seguintes: 15 `ok`, 0 mudanças — idempotência ao vivo confirmada.
- Project: https://github.com/users/lucasmm96/projects/5 — view "Kanban" (BOARD_LAYOUT); groupBy Status pendente de clique na UI (limitação da API registrada).

### Testes

40/40 vitest (API mockada; +6 cenários: substituição do Status default, guardas de não-alteração, view Kanban, regressão do `findProject`) · eslint limpo · execução real conferida.

### Segurança

Tokens nunca versionados (`.env.github`, coberto pelo `.gitignore`); `GITHUB_PROJECTS_TOKEN` = PAT com escopo mínimo de Projects; push autorizado explicitamente pelo autor (D-13).

### Checklist

- [x] Infraestrutura conforme Blueprint aprovado (§10, §21 F3)
- [x] Status derivado com 0 divergências; Kanban reflete as Specs
- [x] Idempotência verificada em execução real
- [x] Testes verdes e lint limpo
- [x] Sem mudança HIGH sem autorização
- [ ] Merge: aguardando aprovação humana do PR
