### PR TITLE
fix(github): spec-sync — secrets em `if` rejeitados pelo schema do Actions

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [development]
     paths: ['.ai/specs/**']
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -38,6 +39,13 @@ jobs:
           node-version: 22
       - name: Spec ↔ Issue
         run: node scripts/spec-github/sync.js
+      # `secrets` não é permitido em condicionais `if` (o schema do Actions rejeita o
+      # workflow) — o passo de Project é condicional via shell: roda quando o secret
+      # GITHUB_PROJECTS_TOKEN existe (o GITHUB_TOKEN do Actions não acessa Projects v2).
       - name: Project sync (requer GITHUB_PROJECTS_TOKEN)
-        if: ${{ secrets.GITHUB_PROJECTS_TOKEN != '' }}
-        run: node scripts/spec-github/project-sync.js
+        run: |
+          if [ -n "$GITHUB_PROJECTS_TOKEN" ]; then
+            node scripts/spec-github/project-sync.js
+          else
+            echo "GITHUB_PROJECTS_TOKEN ausente — passo de Project pulado (setup humano pendente)."
+          fi

--- a/scripts/spec-github/event-driven.test.js
+++ b/scripts/spec-github/event-driven.test.js
@@ -44,12 +44,19 @@ describe('W2 — spec-sync', () => {
     expect(w).toMatch(/^permissions:\n\s+contents: read\n\s+issues: write$/m)
   })
 
-  it('roda os scripts determinísticos; passo de Project condicional ao secret', () => {
+  it('roda os scripts determinísticos; passo de Project condicional ao secret (shell)', () => {
     const w = read('.github/workflows/spec-sync.yml')
     expect(w).toMatch(/node scripts\/spec-github\/sync\.js/)
     expect(w).toMatch(/node scripts\/spec-github\/project-sync\.js/)
-    expect(w).toMatch(/GITHUB_PROJECTS_TOKEN != ''/)
+    expect(w).toMatch(/if \[ -n "\$GITHUB_PROJECTS_TOKEN" \]/)
+    expect(w).not.toMatch(/secrets\.GITHUB_PROJECTS_TOKEN != ''/)
     expect(w).not.toMatch(/anthropics\/claude-code-action/)
+  })
+
+  it('não usa secrets em condicionais if (schema do Actions rejeita)', () => {
+    for (const name of WORKFLOWS) {
+      expect(read(`.github/workflows/${name}`)).not.toMatch(/^\s*if: .*secrets\./m)
+    }
   })
 })
 


### PR DESCRIPTION
**Spec:** ADR-0012 — ([link](.ai/specs/decisions/ADR-0012-spec-driven-github-operations.md))
**Issue:** — (fases do ADR-0012; padrão dos PRs #4/#5/#20/#23/#24/#25/#28)
**Tipo:** DEBT
**Autorização:** correção de infra da F6 — descoberta pelo run ao vivo do W2 (merge do PR #29)

## O que muda

O primeiro run ao vivo do W2 falhou no CARREGAMENTO do workflow (o run aparece com o caminho do arquivo como nome): `if: ${{ secrets.GITHUB_PROJECTS_TOKEN != '' }}` é rejeitado pelo schema — `secrets` não está disponível em condicionais `if`.

- Passo de Project passa a ser condicional via **shell** (`[ -n "$GITHUB_PROJECTS_TOKEN" ]`), com mensagem clara quando o secret está ausente.
- `workflow_dispatch` adicionado ao spec-sync (disparo manual; necessário para re-execução após este fix — o trigger por paths não re-dispára).
- Teste de regressão: nenhum workflow usa `secrets` em `if` (event-driven.test.js).

## Evidências de validação (por AC)

- Run 32092036748 (falha de schema) → correção → re-execução manual via dispatch após o merge (verificação ao vivo da criação da Issue canônica da FEAT-0002).

## Testes

- `npx vitest run scripts/spec-github` → **92/92**
- `npx eslint scripts/spec-github` → limpo

## Segurança

Nenhum segredo adicionado; condicional em shell não expõe valor do secret.

## Checklist

- [x] ACs validadas com evidência (acima)
- [x] Current Specs sincronizadas (N/A — infra)
- [x] Testes: 92/92 + lint limpo
- [x] Sem mudança HIGH sem autorização explícita
- [ ] Merge: aguardando aprovação humana do PR