### PR TITLE
feat(release): release traceability — tabela §23, release-manager e W6 release-verify (F7)

### DIFF
--- a/.ai/specs/CONVENTIONS.md
+++ b/.ai/specs/CONVENTIONS.md
@@ -284,6 +284,16 @@ O agente prepara PRs e nunca aprova o próprio PR. A aprovação humana do PR é
 
 O agente prepara: notas, changelog, tabela de rastreabilidade (Spec → Issue → PR → Release), branch/PR de release, Release DRAFT. **Criação de tag e criação/publicação de Release: confirmação humana explícita.** Alvo de release é registrado em GitHub Milestone.
 
+- Fluxo (Blueprint §12.1): proposta SEMVER + notas (release-manager invoca o especialista release-notes) → confirmação humana da versão → preparação (changelog, tabela, branch/PR de release, DRAFT) → aprovação humana do PR + tag/publicação → pós-publicação (milestone fechado; rastreabilidade verificada — W6 `release-verify`).
+- O corpo da Release inclui as notas no padrão histórico e a tabela de rastreabilidade com formato canônico (um item por Spec da release; `#N` auto-linka no GitHub):
+
+```markdown
+## Rastreabilidade
+| Spec | Issue | PR | Título | Tipo |
+```
+
+Specs arquivadas citam o release no `Implemented Through`.
+
 ### 18.10 Agentes e orquestração
 
 Agentes especializados (`.claude/agents/`): spec-manager (Specs) · github-manager (Issues) · project-manager (Project) · pr-manager (PRs) · release-manager (releases) · test-manager (verificação). Agentes NÃO chamam agentes — o Claude principal orquestra; no modo event-driven, workflows de GitHub Actions executam sequências fixas. Cada artefato tem um único agente dono. O agente `release-notes` é especialista de análise invocado pelo release-manager.

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,57 @@
+---
+name: release-manager
+description: Dono do lifecycle de release do MeuFenil. Use ao preparar uma nova release: reconstrói a história (invoca o especialista release-notes via orquestrador), propõe versão SEMVER com rationale, redige notas + tabela de rastreabilidade §23, prepara branch/PR de release e Release DRAFT; no pós-publicação, fecha o milestone e verifica a rastreabilidade (W6). Nunca cria tag nem publica release; nunca push em branch protegida; nunca decide a versão (propõe); nunca reescreve histórico.
+tools: Read, Grep, Glob, Bash, mcp__github__*
+---
+
+Você é o RELEASE-MANAGER do projeto MeuFenil — dono do lifecycle de release (Blueprint §15.5; CONVENTIONS §18.9; ADR-0012 item 7).
+
+## Regras transversais (Blueprint §15.0 — absolutas)
+
+1. Agentes NÃO chamam agentes — você é orquestrado pelo Claude principal; a análise de release é do especialista `release-notes` (§15.7), invocado pelo orquestrador a seu pedido.
+2. Um dono por artefato: release é seu; Spec é do spec-manager; Issue é do github-manager; Project é do project-manager; PR é do pr-manager.
+3. Execução de código é do Claude principal; você gerencia o artefato Release.
+4. Idempotente: reexecutar não duplica comentário nem DRAFT (verifique sempre o estado real via API antes de agir).
+5. Falhe com erro explícito — `UNKNOWN` é reportado, nunca preenchido.
+6. Fronteira humana embutida: versão SEMVER é decidida pelo humano (você propõe); criação de tag e publicação de Release são humanas — você prepara, recomenda e NUNCA executa.
+
+## Fontes
+
+1. CLAUDE.md §5/§12 (branch model de release) · CONVENTIONS §18.9 (Release) · Blueprint §12 (Release Lifecycle) e §23 (Rastreabilidade)
+2. `.claude/agents/release-notes.md` (especialista de análise — subordinado a você, §15.7)
+3. Padrão histórico real do projeto: `.ai/.temp/analyses/32-release-v1.7.0.md` e irmãos (nunca inventar estilo)
+4. ADR-0012 · Blueprint 38 (APPROVED)
+
+## Responsabilidades (§15.5)
+
+- Reconstruir a história da release — invoca o `release-notes` (via orquestrador) para a análise e a redação.
+- Propor versão SEMVER com rationale — **nunca decide** (confirmação humana da versão, §12.1 passo 3).
+- Redigir notas + tabela de rastreabilidade §23 no corpo da Release (um item por Spec da release; `#N` auto-linka no GitHub):
+
+```markdown
+## Rastreabilidade
+| Spec | Issue | PR | Título | Tipo |
+```
+
+(geração: `scripts/spec-github/lib/release-traceability.js` — `buildTraceabilityTable`.)
+
+- Preparar: changelog, branch de release `release/vX.Y.Z` (de `development`), PR de release (alvo `master`), Release DRAFT.
+- Pós-publicação: fechar o milestone da release e verificar a rastreabilidade (no modo event-driven, o W6 `release-verify` cobre: tabela §23 verificada, milestone fechado, comentário de verificação por Issue canônico).
+
+## Ferramentas (nesta ordem)
+
+1. GitHub MCP (`mcp__github__*`) — releases draft, milestones — quando disponível.
+2. Bash (git log/tag — leitura) + `scripts/spec-github/` (tabela §23).
+3. `release-notes` via orquestrador — você nunca o invoca diretamente.
+
+## Push — regra absoluta (D-3/D-13)
+
+`git push` de work branch / release branch SOMENTE mediante autorização explícita do usuário, executado pelo orquestrador sob aprovação pontual. NUNCA push em branch protegida (`master`) nem push sem autorização.
+
+## Não
+
+- Não cria tag · não publica release · não decide versão (propõe) · não faz push em protegida · não faz deploy/migration prod · não reescreve histórico.
+
+## Stop conditions (fronteira humana)
+
+PARE e reporte quando: confirmação humana da versão ausente · aprovação do PR de release ausente · tag/publicação sem autorização · rastreabilidade com divergência não explicável · `UNKNOWN` que afete versão, notas ou a tabela §23. Explique: (1) achado; (2) por que é ambíguo; (3) alternativas; (4) decisão necessária.

--- a/.claude/agents/release-notes.md
+++ b/.claude/agents/release-notes.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes
-description: Especialista em análise de releases do MeuFenil. Use ao preparar uma nova release: reconstrói a história entre tags a partir do Git e das specs, classifica mudanças e redige release notes em pt-BR no padrão real do projeto. Não executa ações de Git.
+description: Especialista em análise de releases do MeuFenil — subordinado ao release-manager (§15.5/§15.7), que o invoca via orquestrador ao preparar uma nova release: reconstrói a história entre tags a partir do Git e das specs, classifica mudanças e redige release notes em pt-BR no padrão real do projeto. Não executa ações de Git; não decide versão; a orquestração do lifecycle de release é do release-manager.
 tools: Read, Grep, Glob, Bash, Write
 ---
 

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,42 @@
+# W6 — release-verify (Blueprint v1.1-final §18.1): evento release.published →
+# verifica a tabela de rastreabilidade §23 do corpo da Release e fecha o milestone
+# pós-publicação (§12.1 passo 6). Determinístico — a verificação da tabela é
+# checklist mecânico (mesmo desvio justificado da coluna "IA: Sim" do §18.1
+# adotado no W2/W4, autorizado em 2026-08-17 para mecanismos determinísticos).
+#
+# NUNCA cria tag, NUNCA publica release, NUNCA faz push (D-7/§12.2). Falha = job
+# vermelho com log explícito — anomalia registrada (ex.: Release sem a tabela §23,
+# Failure Mode #20: humano decide sobre notas retroativas; nunca apagar a tag).
+name: release-verify
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: release-verify-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # O checkout aponta para o commit da tag publicada — as Specs verificadas
+      # são as exatamente do código entregue na release.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Extrair corpo da Release
+        run: jq -r .release.body "$GITHUB_EVENT_PATH" > /tmp/release-body.md
+      - name: Verificar rastreabilidade (§23) e fechar milestone
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/spec-github/release-verify.js --tag "${{ github.event.release.tag_name }}" --body-file /tmp/release-body.md

--- a/scripts/spec-github/lib/github.js
+++ b/scripts/spec-github/lib/github.js
@@ -96,4 +96,14 @@ export class GitHubClient {
   addComment(number, body) {
     return this.request('POST', `/repos/${this.owner}/${this.repo}/issues/${number}/comments`, { body })
   }
+
+  /** Lista milestones do estado dado (padrão open) — o alvo de release (§18.9). */
+  listMilestones(state = 'open') {
+    return this.request('GET', `/repos/${this.owner}/${this.repo}/milestones?state=${state}&per_page=100`)
+  }
+
+  /** Fecha/reabre um milestone (state: closed|open) — pós-publicação (§12.1 passo 6). */
+  updateMilestone(number, state) {
+    return this.request('PATCH', `/repos/${this.owner}/${this.repo}/milestones/${number}`, { state })
+  }
 }

--- a/scripts/spec-github/lib/release-traceability.js
+++ b/scripts/spec-github/lib/release-traceability.js
@@ -1,0 +1,67 @@
+// Geração e parsing da tabela de rastreabilidade de release (Blueprint v1.1-final §23;
+// CONVENTIONS §18.9): o corpo da Release inclui, além das notas, a tabela
+// `| Spec | Issue | PR | Título | Tipo |`. Números `#N` auto-linkam no GitHub
+// (Issues e PRs compartilham numeração). Funções puras — o release-manager usa a
+// geração no modo interativo; o W6 (release-verify) usa o parsing na verificação.
+
+const TABLE_HEADER = '| Spec | Issue | PR | Título | Tipo |'
+const TABLE_SEPARATOR = '|------|-------|-----|--------|------|'
+
+/** Célula separadora de Markdown (`|---|---|`). */
+function isSeparatorRow(cells) {
+  return cells.length > 0 && cells.every((cell) => /^:?-{2,}:?$/.test(cell.trim()))
+}
+
+/** Extrai o número de células como `#31`, `31` ou `[#31](https://github.com/...)`. */
+function parseNumber(cell) {
+  const match = cell.trim().match(/\d+/)
+  return match ? Number(match[0]) : null
+}
+
+/**
+ * Gera a tabela §23 a partir dos itens da release.
+ * @param {{spec: string, issue: number, pr: number, title: string, type: string}[]} entries
+ */
+export function buildTraceabilityTable(entries) {
+  const rows = [...entries]
+    .sort((a, b) => a.spec.localeCompare(b.spec))
+    .map((e) => `| ${e.spec} | #${e.issue} | #${e.pr} | ${e.title} | ${e.type} |`)
+  return ['## Rastreabilidade', TABLE_HEADER, TABLE_SEPARATOR, ...rows].join('\n')
+}
+
+/**
+ * Faz o parsing da tabela §23 do corpo da Release. Retorna null quando a seção
+ * `## Rastreabilidade` não existe; senão `{ rows, malformedRows }` (linhas com
+ * células faltando são reportadas, nunca assumidas). A seção termina no próximo
+ * heading (`## …`) ou no fim do corpo.
+ */
+export function parseTraceabilityTable(body) {
+  if (typeof body !== 'string') return null
+  const heading = body.match(/(?:^|\n)## Rastreabilidade[^\S\r\n]*(?:\r?\n|$)/)
+  if (!heading) return null
+
+  const rest = body.slice(heading.index + heading[0].length)
+  const nextHeading = rest.search(/\n## |\n---\s*\n/)
+  const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading)
+
+  const rows = []
+  const malformedRows = []
+  for (const line of section.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || !trimmed.startsWith('|')) continue
+    const cells = trimmed.slice(1, -1).split('|').map((cell) => cell.trim())
+    if (cells[0] === 'Spec' || isSeparatorRow(cells)) continue
+
+    const spec = cells[0] || null
+    const issue = parseNumber(cells[1] ?? '')
+    const pr = parseNumber(cells[2] ?? '')
+    const title = cells.slice(3, -1).join(' | ').trim() || null
+    const type = cells[cells.length - 1] || null
+    if (spec && issue !== null && pr !== null && title && type) {
+      rows.push({ spec, issue, pr, title, type })
+    } else {
+      malformedRows.push(line)
+    }
+  }
+  return { rows, malformedRows }
+}

--- a/scripts/spec-github/release-traceability.test.js
+++ b/scripts/spec-github/release-traceability.test.js
@@ -1,0 +1,430 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildTraceabilityTable, parseTraceabilityTable } from './lib/release-traceability.js'
+import { closeMilestone, milestoneMatchesTag, runReleaseVerify, verifyTraceability } from './release-verify.js'
+
+// F7 — Release Traceability (Blueprint §12/§23/§15.5/§18.1; CONVENTIONS §18.9).
+// Matriz de testes da F7 (§29): "geração da tabela de rastreabilidade a partir
+// de dados fictícios" + verificação do W6 + conformidade do agente release-manager,
+// da subordinação do release-notes (§15.7) e do workflow release-verify.
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const read = (rel) => readFileSync(join(ROOT, rel), 'utf8')
+
+const SPEC = (issue) => `# FEAT-0002 — Fixture
+**Type:** FEAT
+**Status:** IMPLEMENTED
+**Title:** Exportar histórico CSV
+**Issue:** #${issue}
+**Created on:** 2026-08-17
+
+## Problem
+Fixture.
+`
+
+const DEBT_SPEC = `# DEBT-0005 — Fixture
+**Type:** DEBT
+**Status:** IMPLEMENTED
+**Title:** Dívida de lint
+**Issue:** #26
+**Created on:** 2026-08-17
+
+## Problem
+Fixture.
+`
+
+const ENTRIES = [
+  { spec: 'DEBT-0005', issue: 26, pr: 28, title: 'Dívida de lint', type: 'DEBT' },
+  { spec: 'FEAT-0002', issue: 31, pr: 29, title: 'Exportar histórico CSV', type: 'FEAT' },
+]
+
+const RELEASE_BODY = `## Release Notes — MeuFenil v1.8.0
+
+Seções por categoria no padrão histórico.
+
+${buildTraceabilityTable(ENTRIES)}
+`
+
+/** Fake REST com captura de chamadas (mesmo padrão do reconcile.test.js). */
+function createFakeRest({ issues = {}, comments = {}, milestones = [] }) {
+  const calls = []
+  const fetchImpl = async (url, init = {}) => {
+    calls.push({ url: String(url), method: init.method ?? 'GET' })
+    if (String(url).includes('/milestones?state=open')) {
+      return { status: 200, ok: true, json: async () => milestones }
+    }
+    if (init.method === 'PATCH' && /\/milestones\/\d+$/.test(String(url))) {
+      return { status: 200, ok: true, json: async () => ({ state: JSON.parse(init.body).state }) }
+    }
+    if (String(url).includes('/comments?per_page')) {
+      const n = Number(String(url).match(/\/issues\/(\d+)\/comments/)[1])
+      return { status: 200, ok: true, json: async () => comments[n] ?? [] }
+    }
+    if (init.method === 'POST' && String(url).endsWith('/comments')) {
+      const n = Number(String(url).match(/\/issues\/(\d+)\/comments/)[1])
+      return { status: 201, ok: true, json: async () => ({ id: 1, body: JSON.parse(init.body).body }) }
+    }
+    const m = String(url).match(/\/issues\/(\d+)$/)
+    if (m) {
+      const n = Number(m[1])
+      if (!(n in issues)) return { status: 404, ok: false, json: async () => ({ message: 'Not Found' }) }
+      return { status: 200, ok: true, json: async () => issues[n] }
+    }
+    throw new Error(`URL não esperada: ${url}`)
+  }
+  return { calls, fetchImpl }
+}
+
+function makeClient(fakeRest) {
+  const token = 'test-token'
+  const get = (url) => fakeRest.fetchImpl(`https://api.github.com${url}`).then((r) => (r.status === 404 ? null : r.json()))
+  const rest = {
+    getIssue: (n) => get(`/repos/o/r/issues/${n}`),
+    listComments: (n) => get(`/repos/o/r/issues/${n}/comments?per_page=100`),
+    addComment: (n, body) =>
+      fakeRest.fetchImpl(`https://api.github.com/repos/o/r/issues/${n}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ body }),
+      }),
+    listMilestones: () => get('/repos/o/r/milestones?state=open&per_page=100'),
+    updateMilestone: (n, state) =>
+      fakeRest.fetchImpl(`https://api.github.com/repos/o/r/milestones/${n}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ state }),
+      }),
+  }
+  return { token, rest }
+}
+
+const VERIFIED_ISSUES = {
+  26: { state: 'closed' },
+  31: { state: 'closed' },
+  28: { state: 'closed', pull_request: { merged_at: '2026-08-18T12:00:00Z' } },
+  29: { state: 'closed', pull_request: { merged_at: '2026-08-18T12:00:00Z' } },
+}
+
+describe('buildTraceabilityTable (§23 — dados fictícios)', () => {
+  it('gera o cabeçalho canônico e as linhas com #N', () => {
+    const table = buildTraceabilityTable(ENTRIES)
+    expect(table).toBe(
+      '## Rastreabilidade\n' +
+        '| Spec | Issue | PR | Título | Tipo |\n' +
+        '|------|-------|-----|--------|------|\n' +
+        '| DEBT-0005 | #26 | #28 | Dívida de lint | DEBT |\n' +
+        '| FEAT-0002 | #31 | #29 | Exportar histórico CSV | FEAT |'
+    )
+  })
+
+  it('ordena por Spec ID', () => {
+    const table = buildTraceabilityTable([ENTRIES[0], ENTRIES[1]])
+    expect(table.indexOf('DEBT-0005')).toBeLessThan(table.indexOf('FEAT-0002'))
+  })
+
+  it('round-trip: parse(build(entries)) recupera os mesmos itens', () => {
+    const parsed = parseTraceabilityTable(buildTraceabilityTable(ENTRIES))
+    expect(parsed.rows).toEqual(ENTRIES)
+    expect(parsed.malformedRows).toEqual([])
+  })
+})
+
+describe('parseTraceabilityTable', () => {
+  it('retorna null quando a seção ## Rastreabilidade não existe', () => {
+    expect(parseTraceabilityTable('# Só notas, sem tabela')).toBeNull()
+  })
+
+  it('ignora cabeçalho e separador; preserva a ordem das linhas', () => {
+    const parsed = parseTraceabilityTable(RELEASE_BODY)
+    expect(parsed.rows).toHaveLength(2)
+    expect(parsed.rows[0]).toMatchObject({ spec: 'DEBT-0005', issue: 26, pr: 28, type: 'DEBT' })
+  })
+
+  it('tolera links markdown nas células ([#31](url))', () => {
+    const body = `## Rastreabilidade
+| Spec | Issue | PR | Título | Tipo |
+|------|-------|-----|--------|------|
+| FEAT-0002 | [#31](https://github.com/lucasmm96/meufenil/issues/31) | [#29](https://github.com/lucasmm96/meufenil/pull/29) | Exportar histórico CSV | FEAT |
+`
+    expect(parseTraceabilityTable(body).rows[0]).toMatchObject({ issue: 31, pr: 29 })
+  })
+
+  it('tolera finais de linha CRLF (bodies do GitHub)', () => {
+    const parsed = parseTraceabilityTable(RELEASE_BODY.replace(/\n/g, '\r\n'))
+    expect(parsed.rows).toHaveLength(2)
+  })
+
+  it('reporta linha malformada em malformedRows (nunca assume)', () => {
+    const body = `## Rastreabilidade
+| Spec | Issue | PR | Título | Tipo |
+|------|-------|-----|--------|------|
+| FEAT-0002 | #31 | | sem PR | FEAT |
+`
+    const parsed = parseTraceabilityTable(body)
+    expect(parsed.rows).toEqual([])
+    expect(parsed.malformedRows).toHaveLength(1)
+  })
+})
+
+describe('milestoneMatchesTag (§24 — milestone = versão)', () => {
+  it('normaliza o prefixo v', () => {
+    expect(milestoneMatchesTag('v1.8.0', '1.8.0')).toBe(true)
+    expect(milestoneMatchesTag('1.8.0', 'v1.8.0')).toBe(true)
+    expect(milestoneMatchesTag('v1.8.0', 'v1.8.0')).toBe(true)
+  })
+
+  it('rejeita versões diferentes', () => {
+    expect(milestoneMatchesTag('v1.8.0', 'v1.9.0')).toBe(false)
+  })
+})
+
+describe('verifyTraceability (W6)', () => {
+  let tempDirs = []
+
+  afterEach(() => {
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+    tempDirs = []
+  })
+
+  function tempBase() {
+    const dir = mkdtempSync(join(tmpdir(), 'release-verify-'))
+    tempDirs.push(dir)
+    mkdirSync(join(dir, 'archive', 'implemented', 'features'), { recursive: true })
+    mkdirSync(join(dir, 'archive', 'implemented', 'technical-debt'), { recursive: true })
+    writeFileSync(join(dir, 'archive', 'implemented', 'features', 'FEAT-0002-fixture.md'), SPEC(31))
+    writeFileSync(join(dir, 'archive', 'implemented', 'technical-debt', 'DEBT-0005-fixture.md'), DEBT_SPEC)
+    return dir
+  }
+
+  async function verifyWith(issues, base, body = RELEASE_BODY) {
+    const fakeRest = createFakeRest({ issues })
+    const { rest } = makeClient(fakeRest)
+    const result = await verifyTraceability({ body, baseDir: base, rest })
+    return { result, fakeRest }
+  }
+
+  it('release inteira verificada → verified, sem transporte de escrita', async () => {
+    const { result, fakeRest } = await verifyWith(VERIFIED_ISSUES, tempBase())
+    expect(result.action).toBe('verified')
+    expect(result.checks.every((c) => c.ok)).toBe(true)
+    expect(fakeRest.calls.filter((c) => c.method !== 'GET').length).toBe(0)
+  })
+
+  it('Issue aberto → divergence', async () => {
+    const { result } = await verifyWith({ ...VERIFIED_ISSUES, 31: { state: 'open' } }, tempBase())
+    expect(result.action).toBe('divergence')
+    const check = result.checks.find((c) => c.row.spec === 'FEAT-0002')
+    expect(check).toMatchObject({ issueClosed: false, ok: false })
+  })
+
+  it('PR não merged (merged_at null) → divergence', async () => {
+    const { result } = await verifyWith(
+      { ...VERIFIED_ISSUES, 29: { state: 'closed', pull_request: { merged_at: null } } },
+      tempBase()
+    )
+    expect(result.action).toBe('divergence')
+    const check = result.checks.find((c) => c.row.spec === 'FEAT-0002')
+    expect(check).toMatchObject({ prMerged: false, ok: false })
+  })
+
+  it('PR inexistente → divergence', async () => {
+    const issues = { ...VERIFIED_ISSUES }
+    delete issues[29]
+    const { result } = await verifyWith(issues, tempBase())
+    expect(result.action).toBe('divergence')
+    const check = result.checks.find((c) => c.row.spec === 'FEAT-0002')
+    expect(check).toMatchObject({ prExists: false, isPr: null })
+  })
+
+  it('frontmatter Issue: da Spec não bate com a linha → divergence', async () => {
+    const base = tempBase()
+    const { result } = await verifyWith(VERIFIED_ISSUES, base, buildTraceabilityTable([{ ...ENTRIES[1], issue: 99 }]))
+    expect(result.action).toBe('divergence')
+    expect(result.checks[0]).toMatchObject({ specExists: true, specIssueMatches: false })
+  })
+
+  it('Spec ausente do repositório → divergence', async () => {
+    const { result } = await verifyWith(
+      VERIFIED_ISSUES,
+      tempBase(),
+      buildTraceabilityTable([{ spec: 'FEAT-9999', issue: 31, pr: 29, title: 'Inexistente', type: 'FEAT' }])
+    )
+    expect(result.action).toBe('divergence')
+    expect(result.checks[0]).toMatchObject({ specExists: false })
+  })
+
+  it('sem a tabela §23 → no-table (Failure Mode #20)', async () => {
+    const { result } = await verifyWith(VERIFIED_ISSUES, tempBase(), '# Só notas, sem tabela')
+    expect(result.action).toBe('no-table')
+    expect(result.checks).toEqual([])
+  })
+
+  it('linhas malformadas → malformed-rows', async () => {
+    const body = `## Rastreabilidade
+| Spec | Issue | PR | Título | Tipo |
+|------|-------|-----|--------|------|
+| FEAT-0002 | #31 | | sem PR | FEAT |
+`
+    const { result } = await verifyWith(VERIFIED_ISSUES, tempBase(), body)
+    expect(result.action).toBe('malformed-rows')
+    expect(result.malformedRows).toHaveLength(1)
+  })
+
+  it('sem transporte (rest null) → checks parciais e divergence', async () => {
+    const result = await verifyTraceability({ body: RELEASE_BODY, baseDir: tempBase(), rest: null })
+    expect(result.action).toBe('divergence')
+    expect(result.checks[0]).toMatchObject({ issueExists: false, issueClosed: null })
+  })
+})
+
+describe('runReleaseVerify (comentários + milestone)', () => {
+  let tempDirs = []
+
+  afterEach(() => {
+    for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+    tempDirs = []
+  })
+
+  function tempBase() {
+    const dir = mkdtempSync(join(tmpdir(), 'release-verify-run-'))
+    tempDirs.push(dir)
+    mkdirSync(join(dir, 'archive', 'implemented', 'features'), { recursive: true })
+    mkdirSync(join(dir, 'archive', 'implemented', 'technical-debt'), { recursive: true })
+    writeFileSync(join(dir, 'archive', 'implemented', 'features', 'FEAT-0002-fixture.md'), SPEC(31))
+    writeFileSync(join(dir, 'archive', 'implemented', 'technical-debt', 'DEBT-0005-fixture.md'), DEBT_SPEC)
+    return dir
+  }
+
+  it('verified → comenta cada Issue canônico e fecha o milestone da tag', async () => {
+    const fakeRest = createFakeRest({
+      issues: VERIFIED_ISSUES,
+      milestones: [{ number: 7, title: 'v1.8.0' }],
+    })
+    const { rest } = makeClient(fakeRest)
+
+    const result = await runReleaseVerify({ tag: 'v1.8.0', body: RELEASE_BODY, baseDir: tempBase(), rest })
+
+    expect(result.action).toBe('verified')
+    expect(result.milestone).toEqual({ closed: 'v1.8.0' })
+    const posts = fakeRest.calls.filter((c) => c.method === 'POST')
+    expect(posts).toHaveLength(2)
+    expect(fakeRest.calls.some((c) => c.method === 'PATCH' && c.url.includes('/milestones/7'))).toBe(true)
+  })
+
+  it('não repete comentário quando o marker da tag já existe (idempotente)', async () => {
+    const fakeRest = createFakeRest({
+      issues: VERIFIED_ISSUES,
+      comments: { 26: [{ body: '<!-- sync:release-verify:v1.8.0 -->\nanterior' }] },
+      milestones: [{ number: 7, title: 'v1.8.0' }],
+    })
+    const { rest } = makeClient(fakeRest)
+
+    await runReleaseVerify({ tag: 'v1.8.0', body: RELEASE_BODY, baseDir: tempBase(), rest })
+
+    expect(fakeRest.calls.filter((c) => c.method === 'POST')).toHaveLength(1)
+  })
+
+  it('divergence → nenhum comentário, nenhum milestone alterado', async () => {
+    const fakeRest = createFakeRest({
+      issues: { ...VERIFIED_ISSUES, 31: { state: 'open' } },
+      milestones: [{ number: 7, title: 'v1.8.0' }],
+    })
+    const { rest } = makeClient(fakeRest)
+
+    const result = await runReleaseVerify({ tag: 'v1.8.0', body: RELEASE_BODY, baseDir: tempBase(), rest })
+
+    expect(result.action).toBe('divergence')
+    expect(fakeRest.calls.filter((c) => c.method !== 'GET')).toHaveLength(0)
+  })
+
+  it('milestone ausente ou ambíguo → nada fechado (nota, sem PATCH)', async () => {
+    const none = createFakeRest({ issues: VERIFIED_ISSUES, milestones: [] })
+    expect(await closeMilestone({ tag: 'v1.8.0', rest: makeClient(none).rest })).toHaveProperty('note')
+
+    const ambiguous = createFakeRest({
+      issues: VERIFIED_ISSUES,
+      milestones: [
+        { number: 7, title: 'v1.8.0' },
+        { number: 8, title: '1.8.0' },
+      ],
+    })
+    const rest = makeClient(ambiguous).rest
+    await closeMilestone({ tag: 'v1.8.0', rest })
+    expect(ambiguous.calls.filter((c) => c.method === 'PATCH')).toHaveLength(0)
+  })
+
+  it('dry-run → sem comentários e sem milestone', async () => {
+    const fakeRest = createFakeRest({ issues: VERIFIED_ISSUES, milestones: [{ number: 7, title: 'v1.8.0' }] })
+    const { rest } = makeClient(fakeRest)
+
+    const result = await runReleaseVerify({ tag: 'v1.8.0', body: RELEASE_BODY, baseDir: tempBase(), rest, dryRun: true })
+
+    expect(result.action).toBe('verified')
+    expect(fakeRest.calls.filter((c) => c.method !== 'GET')).toHaveLength(0)
+  })
+})
+
+describe('agente release-manager (§15.5)', () => {
+  it('existe com frontmatter completo (name/description/tools)', () => {
+    const a = read('.claude/agents/release-manager.md')
+    expect(a).toMatch(/^---\nname: release-manager/)
+    expect(a).toMatch(/description: .+/)
+    expect(a).toMatch(/tools: .+/)
+  })
+
+  it('declara fronteira humana, stop conditions e boundaries §15.5', () => {
+    const a = read('.claude/agents/release-manager.md')
+    expect(a).toMatch(/fronteira humana/i)
+    expect(a).toMatch(/stop conditions/i)
+    expect(a).toMatch(/^## Não/m)
+    expect(a).toMatch(/não publica release/i)
+    expect(a).toMatch(/não cria tag/i)
+    expect(a).toMatch(/não decide versão/i)
+    expect(a).toMatch(/não reescreve histórico/i)
+  })
+
+  it('§15.0: agentes não chamam agentes — release-notes é invocado via orquestrador', () => {
+    const a = read('.claude/agents/release-manager.md')
+    expect(a).toMatch(/agentes NÃO chamam agentes/i)
+    expect(a).toMatch(/release-notes.*orquestrador|orquestrador.*release-notes/is)
+  })
+
+  it('referencia a tabela §23 com o formato canônico', () => {
+    const a = read('.claude/agents/release-manager.md')
+    expect(a).toMatch(/\| Spec \| Issue \| PR \| Título \| Tipo \|/)
+  })
+})
+
+describe('release-notes (§15.7 — subordinação)', () => {
+  it('a description indica a subordinação ao release-manager', () => {
+    const description = read('.claude/agents/release-notes.md').match(/^description: (.+)$/m)[1]
+    expect(description).toMatch(/subordinado ao release-manager/i)
+    expect(description).toMatch(/§15\.5\/§15\.7/)
+  })
+})
+
+describe('W6 — release-verify.yml (§18.1)', () => {
+  it('dispara em release.published com permissões mínimas (issues: write, contents: read)', () => {
+    const w = read('.github/workflows/release-verify.yml')
+    expect(w).toMatch(/^on:\n\s+release:\n\s+types: \[published\]/m)
+    expect(w).toMatch(/^permissions:\n\s+contents: read\n\s+issues: write$/m)
+    expect(w).toMatch(/^concurrency:/m)
+    expect(w).toMatch(/timeout-minutes:/)
+  })
+
+  it('roda o release-verify.js com a tag e o corpo extraídos do evento', () => {
+    const w = read('.github/workflows/release-verify.yml')
+    expect(w).toMatch(/jq -r \.release\.body/)
+    expect(w).toMatch(/node scripts\/spec-github\/release-verify\.js --tag "\$\{\{ github\.event\.release\.tag_name \}\}" --body-file \/tmp\/release-body\.md/)
+  })
+
+  it('não usa secrets em condicionais if (schema do Actions rejeita)', () => {
+    expect(read('.github/workflows/release-verify.yml')).not.toMatch(/^\s*if: .*secrets\./m)
+  })
+
+  it('nunca faz push, nunca cria tag (D-7: tag/publicação são humanas)', () => {
+    const w = read('.github/workflows/release-verify.yml')
+    expect(w).not.toMatch(/git push|git tag/)
+  })
+})

--- a/scripts/spec-github/release-verify.js
+++ b/scripts/spec-github/release-verify.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// W6 — release-verify (Blueprint v1.1-final §18.1): evento release.published →
+// verifica a tabela de rastreabilidade §23 do corpo da Release e fecha o milestone
+// pós-publicação (§12.1 passo 6). Determinístico — a verificação da tabela é
+// checklist mecânico (mesmo desvio justificado da coluna "IA: Sim" do §18.1
+// adotado no W2/W4, autorizado em 2026-08-17). NUNCA cria tag, NUNCA publica
+// release, NUNCA push. Falha = job vermelho com log explícito (anomalia
+// registrada — Failure Mode #20: humano decide; nunca apagar a tag).
+//
+// Uso:
+//   node scripts/spec-github/release-verify.js --tag vX.Y.Z --body-file <md> [--dry-run]
+
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { listSpecs } from './lib/specs.js'
+import { parseTraceabilityTable } from './lib/release-traceability.js'
+import { GitHubClient } from './lib/github.js'
+import { loadToken } from './lib/env.js'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const SPECS_DIR = join(REPO_ROOT, '.ai', 'specs')
+
+/** Aceita as duas formas: `--tag=v1.8.0` e `--tag v1.8.0` (o workflow usa a segunda). */
+export function parseArgs(argv) {
+  const args = { dryRun: false, tag: null, bodyFile: null, repo: 'lucasmm96/meufenil' }
+  const value = (arg, i) => (arg.includes('=') ? arg.split('=')[1] : argv[i + 1])
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--dry-run') args.dryRun = true
+    else if (arg.startsWith('--tag')) args.tag = value(arg, i)
+    else if (arg.startsWith('--body-file')) args.bodyFile = value(arg, i)
+    else if (arg.startsWith('--repo')) args.repo = value(arg, i)
+  }
+  return args
+}
+
+/** Compara milestone e tag normalizando o prefixo `v` (milestone = versão, §24). */
+export function milestoneMatchesTag(milestoneTitle, tag) {
+  return String(milestoneTitle).trim().replace(/^v/i, '') === String(tag).trim().replace(/^v/i, '')
+}
+
+/**
+ * Verifica a tabela §23 de uma release publicada. Para cada linha: a Spec existe
+ * no repositório (listSpecs), o frontmatter `Issue:` bate, o Issue está fechado e
+ * o PR foi merged (o endpoint de Issue expõe `pull_request.merged_at` — só
+ * `issues: write` basta, §18.1). Nunca altera nada — apenas verifica.
+ */
+export async function verifyTraceability({ body, baseDir, rest }) {
+  const table = parseTraceabilityTable(body)
+  if (!table) return { action: 'no-table', checks: [] }
+
+  const specs = listSpecs(baseDir)
+  const checks = []
+  for (const row of table.rows) {
+    const spec = specs.find((s) => s.id === row.spec)
+    const issue = rest ? await rest.getIssue(row.issue) : null
+    const prIssue = rest ? await rest.getIssue(row.pr) : null
+    const issueClosed = issue ? issue.state === 'closed' : null
+    const prExists = Boolean(prIssue)
+    const isPr = prExists ? Boolean(prIssue.pull_request) : null
+    const prMerged = isPr ? Boolean(prIssue.pull_request.merged_at) : null
+    checks.push({
+      row,
+      specExists: Boolean(spec),
+      specIssueMatches: spec ? spec.issue === row.issue : false,
+      issueExists: Boolean(issue),
+      issueClosed,
+      prExists,
+      isPr,
+      prMerged,
+      ok: Boolean(spec) && spec.issue === row.issue && issueClosed === true && prMerged === true,
+    })
+  }
+
+  if (table.malformedRows.length > 0) return { action: 'malformed-rows', checks, malformedRows: table.malformedRows }
+  const ok = checks.length > 0 && checks.every((c) => c.ok)
+  return { action: ok ? 'verified' : 'divergence', checks }
+}
+
+/** Comentário por Issue canônico (idempotente via marker com a tag). */
+function verificationComment(tag, row) {
+  return (
+    `<!-- sync:release-verify:${tag} -->\n` +
+    `✅ Rastreabilidade verificada (W6): Spec \`${row.spec}\` · Issue #${row.issue} fechado · ` +
+    `PR #${row.pr} merged · Release ${tag} publicada.`
+  )
+}
+
+/** Posta os comentários de verificação quando a release inteira verifica. */
+export async function postVerificationComments({ tag, checks, rest }) {
+  for (const { row } of checks) {
+    const comments = (await rest.listComments(row.issue)) ?? []
+    const alreadyCommented = comments.some((c) => c.body?.includes(`sync:release-verify:${tag}`))
+    if (alreadyCommented) continue
+    await rest.addComment(row.issue, verificationComment(tag, row))
+  }
+}
+
+/** Fecha o milestone aberto correspondente à tag (§12.1 passo 6); nada quando ambíguo. */
+export async function closeMilestone({ tag, rest }) {
+  const milestones = (await rest.listMilestones()) ?? []
+  const matching = milestones.filter((m) => milestoneMatchesTag(m.title, tag))
+  if (matching.length === 1) {
+    await rest.updateMilestone(matching[0].number, 'closed')
+    return { closed: matching[0].title }
+  }
+  return matching.length === 0 ? { note: `nenhum milestone aberto corresponde à tag ${tag}` } : { note: 'ambiguidade' }
+}
+
+/** Runner completo do W6: verifica e, quando a release inteira verifica, comenta e fecha o milestone. */
+export async function runReleaseVerify({ tag, body, baseDir, rest, dryRun = false }) {
+  const result = await verifyTraceability({ body, baseDir, rest })
+  if (dryRun || result.action !== 'verified') return result
+  await postVerificationComments({ tag, checks: result.checks, rest })
+  const milestone = await closeMilestone({ tag, rest })
+  return { ...result, milestone }
+}
+
+function logChecks(checks) {
+  for (const { row, specExists, specIssueMatches, issueExists, issueClosed, prExists, isPr, prMerged, ok } of checks) {
+    if (ok) {
+      console.log(`✅ ${row.spec} · Issue #${row.issue} fechado · PR #${row.pr} merged`)
+      continue
+    }
+    const problems = []
+    if (!specExists) problems.push(`Spec ${row.spec} não encontrada no repositório`)
+    if (!specIssueMatches) problems.push(`frontmatter Issue: da Spec ${row.spec} não bate com #${row.issue}`)
+    if (!issueExists) problems.push(`Issue #${row.issue} inexistente`)
+    if (issueClosed === false) problems.push(`Issue #${row.issue} aberto (esperado fechado)`)
+    if (!prExists) problems.push(`PR #${row.pr} inexistente`)
+    if (prExists && isPr === false) problems.push(`#${row.pr} não é um PR`)
+    if (isPr && prMerged === false) problems.push(`PR #${row.pr} não merged`)
+    console.error(`❌ ${row.spec} — ${problems.join('; ')}`)
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2))
+  const token = loadToken(REPO_ROOT)
+  if (!args.tag || !args.bodyFile) {
+    console.error('Uso: node scripts/spec-github/release-verify.js --tag vX.Y.Z --body-file <md> [--dry-run]')
+    process.exit(1)
+  }
+  if (!token && !args.dryRun) {
+    console.error('GITHUB_TOKEN ausente — defina em .env.github (não versionado) ou via variável de ambiente.')
+    process.exit(1)
+  }
+
+  try {
+    const body = readFileSync(args.bodyFile, 'utf8')
+    const [owner, repo] = args.repo.split('/')
+    const client = token ? new GitHubClient({ token, owner, repo }) : null
+    const rest = client
+      ? {
+          getIssue: (n) => client.getIssue(n),
+          listComments: (n) => client.listComments(n),
+          addComment: (n, b) => client.addComment(n, b),
+          listMilestones: () => client.listMilestones(),
+          updateMilestone: (n, state) => client.updateMilestone(n, state),
+        }
+      : null
+
+    const result = await runReleaseVerify({ tag: args.tag, body, baseDir: SPECS_DIR, rest, dryRun: args.dryRun })
+    console.log(`release-verify ${args.tag}: ${result.action}`)
+
+    if (args.dryRun) {
+      logChecks(result.checks)
+      console.log('dry-run — nenhum comentário postado, nenhum milestone alterado')
+      process.exit(0)
+    }
+
+    if (result.action === 'verified') {
+      logChecks(result.checks)
+      if (result.milestone?.closed) console.log(`milestone ${result.milestone.closed} fechado (§12.1 passo 6)`)
+      if (result.milestone?.note) console.log(result.milestone.note)
+      process.exit(0)
+    }
+
+    if (result.action === 'no-table') {
+      console.error('ANOMALIA (Failure Mode #20): Release publicada sem a tabela de rastreabilidade §23 no corpo.')
+      console.error('O corpo da Release deve incluir (um item por Spec da release):')
+      console.error('## Rastreabilidade')
+      console.error('| Spec | Issue | PR | Título | Tipo |')
+      console.error('Nenhuma ação automática foi executada — humano decide (notas retroativas ou registro da anomalia); nunca apagar a tag.')
+      process.exit(1)
+    }
+
+    if (result.action === 'malformed-rows') {
+      console.error('Linhas malformadas na tabela §23:')
+      for (const line of result.malformedRows) console.error(`  ${line}`)
+      logChecks(result.checks)
+      process.exit(1)
+    }
+
+    console.error('Divergência na rastreabilidade — verificar acima. Nenhuma ação automática além do registro.')
+    logChecks(result.checks)
+    process.exit(1)
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
**Spec:** ADR-0012 — Spec-Driven GitHub Operations (Fase 7 — Release Traceability) · [ADR](.ai/specs/decisions/ADR-0012-spec-driven-github-operations.md)
**Issue:** — (fases do ADR-0012 não têm Issue canônica — padrão dos PRs anteriores)
**Tipo:** FEAT
**Autorização:** Blueprint v1.1-final APPROVED + pedido explícito do autor para a Fase 7 (2026-08-18)

## O que muda

- **release-manager** (novo agente, §15.5): dono do lifecycle de release — reconstrói história (invoca o release-notes via orquestrador), propõe versão SEMVER com rationale, prepara notas + tabela §23, branch/PR de release, DRAFT; pós-publicação fecha o milestone e verifica a rastreabilidade. Nunca cria tag/publica release; nunca decide versão; nunca reescreve histórico.
- **release-notes** (§15.7): apenas a `description` atualizada para indicar a subordinação ao release-manager.
- **Tabela de rastreabilidade §23**: gerador + parser (`scripts/spec-github/lib/release-traceability.js`, funções puras) e formato canônico documentado na CONVENTIONS §18.9.
- **W6 release-verify**: workflow (`release.published`) + script determinístico que verifica cada linha da tabela (Spec existe no commit da tag, Issue fechado, PR merged), comenta os Issues canônicos (marker de dedup por tag) e fecha o milestone (§12.1 passo 6). Falha = job vermelho com log explícito (anomalia — Failure Mode #20).
- **GitHubClient**: `listMilestones`/`updateMilestone` (cabe em `issues: write` — permissões mínimas §18.1).

## Evidências de validação (por AC)

- Blueprint §29 (matriz F7): geração da tabela a partir de dados fictícios → `release-traceability.test.js` (round-trip geração→parsing, parsing tolerante a links/CRLF, malformadas reportadas).
- Blueprint §30 item 8: a entrega da F7 é o mecanismo (geração + verificação); a evidência final acontece na primeira release pós-ecossistema (entregável verificável da fase).
- Idempotência (AC 4): comentário de verificação com marker por tag — reexecução não duplica (testado); milestone fechado uma única vez.

## Testes

- `npx vitest run scripts/spec-github` → **125/125** (33 novos)
- `npx eslint scripts/spec-github` → limpo
- `npm run test:run` → **322/322** (suíte completa)
- Smoke test CLI (dry-run, sem transporte): corpo real gerado com FEAT-0002/DEBT-0005 → parse correto, Issues abertos detectados como divergência esperada, nenhuma escrita

## Segurança

- W6 com permissões mínimas (§18.1): `contents: read`, `issues: write`; nunca push; nunca cria tag/publica release (D-7); sem secrets em condicionais `if` (schema do Actions).
- Desvio justificado da coluna "IA: Sim" do §18.1: a verificação da tabela é checklist mecânico → script determinístico, mesmo padrão autorizado para W2/W4 em 2026-08-17 (sem roundtrip de LLM, sem dependência do setup humano pendente do Claude Code Action).
- Nenhuma mudança em schema/RLS/RPC/segurança do produto.

## Checklist

- [x] ACs validadas com evidência (acima)
- [x] Current Specs sincronizadas: CONVENTIONS §18.9 (formato canônico §23 + fluxo); ADR-0012 item 7 e §18.10 já refletiam o modelo (REVIEW, sem UPDATE)
- [x] Testes: vitest 125/125 · eslint limpo · suíte completa 322/322
- [x] Sem mudança HIGH sem autorização explícita (desvio determinístico do W6 sinalizado acima, no padrão já autorizado)
- [ ] Merge: aguardando aprovação humana do PR
