### PR TITLE
fix(keepalive): restaurar multi-alvo prod+dev com alvo dev endurecido (DEBT-0006)

### DIFF
--- a/.ai/specs/current/backend/api-keepalive.md
+++ b/.ai/specs/current/backend/api-keepalive.md
@@ -1,71 +1,72 @@
 # API Route — /api/keepalive
 
-**Última verificação:** 2026-08-15 (DEBT-0003)
+**Última verificação:** 2026-08-23 (DEBT-0006)
 **Código:** `api/keepalive.ts` — função Vercel serverless (Node)
 
 ## Propósito
 
-Manter os projetos Supabase gratuitos fora do estado de pausa por inatividade: executada diariamente, faz uma leitura mínima na tabela `public.usuarios` do banco do ambiente atual e persiste o resultado da execução em `background_job_executions`.
+Manter os projetos Supabase gratuitos fora do estado de pausa por inatividade: executada diariamente, faz uma leitura mínima na tabela `public.usuarios` dos **dois** bancos (produção e dev) por execução e persiste o resultado de cada alvo em `background_job_executions` do respectivo banco.
 
 ## Trigger e cron
 
 - Vercel Cron: `0 12 * * *` UTC (≈09:00 America/Sao_Paulo em horário normal) — declarado em `vercel.json` `[CONFIRMED: configuration — vercel.json]`.
-- Handler Node-style (`(req, res) => void`), export default `[CONFIRMED: code — api/keepalive.ts:148]`.
+- Handler Node-style (`(req, res) => void`), export default `[CONFIRMED: code — api/keepalive.ts]`.
 
 ## Ambientes e alvos
 
-- Ambiente da execução: `VERCEL_ENV === "production"` → `prod`; caso contrário → `dev` `[CONFIRMED: code — api/keepalive.ts:46-48]`.
-- **Um único alvo por execução** (o banco do ambiente atual):
-  - prod → label `meufenil`, env `prod` (credenciais: `KEEPALIVE_SUPABASE_URL`/`KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY`, fallback `VITE_SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`)
-  - dev → label `meufenil-dev`, env `dev` (credenciais: `KEEPALIVE_DEV_*`, mesmo fallback) `[CONFIRMED: code — api/keepalive.ts:50-72]`
-- **Divergência RESOLVIDA:** o README descrevia que a rota acessava os DOIS bancos por execução e que `200` indicava sucesso em ambos; o README foi corrigido pelo DEBT-0003 (2026-08-15) e agora documenta 1 alvo por execução, alinhado ao código `[CONFIRMED: documentation — README.md "Keepalive diário"; code — api/keepalive.ts]`.
+- **Dois alvos por execução** (independente de `VERCEL_ENV`):
+  - prod → label `meufenil`, env `prod` (credenciais: `KEEPALIVE_SUPABASE_URL`/`KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY`, fallback `VITE_SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` e `SUPABASE_URL`)
+  - dev → label `meufenil-dev`, env `dev` (credenciais: `KEEPALIVE_DEV_SUPABASE_URL`/`KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY` — **obrigatórias, sem fallback**; ver "Endurecimento" abaixo) `[CONFIRMED: code — api/keepalive.ts resolveKeepaliveTargets]`
+- **Endurecimento (DEBT-0006, 2026-08-23):** o alvo dev exige as próprias variáveis — o fallback histórico apontaria para `VITE_SUPABASE_URL`/`SUPABASE_URL` (banco de PRODUÇÃO) e gravaria linhas `environment = 'dev'` no banco errado; env dev ausente → `500` explícito `[CONFIRMED: code — api/keepalive.ts]`.
+- **Histórico:** `879a6c0` (2026-08-11, release v1.6.0) trocou o multi-alvo por alvo único resolvido por `VERCEL_ENV` — regressão que deixou o ambiente dev sem keepalive; DEBT-0006 (2026-08-23) restaurou o multi-alvo `[CONFIRMED: git — api/keepalive.ts@879a6c0, api/keepalive.ts@879a6c0^]`.
 
 ## Sequência de execução
 
 1. Método: apenas `GET` e `HEAD`; caso contrário `405` + `Allow: GET, HEAD` `[CONFIRMED: code]`.
-2. Gera `runId = crypto.randomUUID()`.
-3. `pingProject(target)`: cria cliente supabase-js com **service role** (`autoRefreshToken: false`, `persistSession: false`), executa `SELECT id FROM usuarios LIMIT 1`, mede `elapsedMs` `[CONFIRMED: code — api/keepalive.ts:83-119]`.
-4. `persistProjectExecution`: grava em `background_job_executions` via [background-jobs.md](background-jobs.md) (`job_key = "keepalive"`, `status = success|failure`, `details = { target, table: "usuarios", operation: "select", limit: 1 }`). **Falha na persistência é logada e NÃO altera a resposta** (o resultado do ping manda) `[CONFIRMED: code — api/keepalive.ts:121-146,168-175]`.
-5. Resposta: `200` se o ping ok, `500` se falhou — corpo `{ ok, runId, durationMs, projects: [projeto] }`, `Cache-Control: no-store` `[CONFIRMED: code]`.
-6. Falha inesperada (ex.: env ausente): `500` com `{ ok: false, error: mensagem }` `[CONFIRMED: code — api/keepalive.ts:195-203]`.
+2. Gera `runId = crypto.randomUUID()` e resolve os DOIS alvos (prod + dev) `[CONFIRMED: code]`.
+3. `pingProject(target)` por alvo em `Promise.allSettled`: cria cliente supabase-js com **service role** (`autoRefreshToken: false`, `persistSession: false`), executa `SELECT id FROM usuarios LIMIT 1`, mede `elapsedMs` — falha de um alvo não impede o outro `[CONFIRMED: code — api/keepalive.ts]`.
+4. `persistProjectExecution` por alvo no **banco do próprio alvo** (mesmo `runId`): grava em `background_job_executions` via [background-jobs.md](background-jobs.md) (`job_key = "keepalive"`, `status = success|failure`, `details = { target, table: "usuarios", operation: "select", limit: 1 }`). **Falha na persistência é logada e NÃO altera a resposta** (o resultado do ping manda) `[CONFIRMED: code — api/keepalive.ts]`.
+5. Resposta: `200` apenas se os DOIS alvos ok; `500` se qualquer alvo falhou (`projects.every`) — corpo `{ ok, runId, durationMs, projects: [prod, dev] }`, `Cache-Control: no-store` `[CONFIRMED: code; decisão OQ-1 do DEBT-0006]`.
+6. Falha inesperada (ex.: env dev ausente): `500` com `{ ok: false, error: mensagem }` `[CONFIRMED: code]`.
 
 ## Autenticação / autorização
 
 - Nenhuma autenticação na rota em si (não valida Bearer nem signature de cron) `[CONFIRMED: code]`.
-- Acesso ao banco via service role (bypassa RLS) — leitura de 1 linha de `usuarios` e INSERT em `background_job_executions` `[CONFIRMED: code, database]`.
+- Acesso aos bancos via service role (bypassa RLS) — leitura de 1 linha de `usuarios` e INSERT em `background_job_executions` em cada banco `[CONFIRMED: code, database]`.
 - RLS de `background_job_executions` não possui policies de INSERT — apenas o canal service role grava (ver [../database/background_job_executions.md](../database/background_job_executions.md)) `[CONFIRMED: database]`.
 
 ## Tratamento de erros
 
-- Erro no ping → resultado `{ ok: false, error: message }` e status `500` `[CONFIRMED: code]`.
+- Erro no ping de um alvo → resultado `{ ok: false, error: message }` para aquele alvo e status `500` (se qualquer alvo falhou) `[CONFIRMED: code]`.
 - Erro na persistência → `console.error` `[keepalive] failed to persist ...` e execução continua `[CONFIRMED: code]`.
-- Env ausente → exceção `Missing environment variable: ...` → `500` `[CONFIRMED: code]`.
+- Env ausente (inclui `KEEPALIVE_DEV_*` faltando) → exceção `Missing environment variable: ...` → `500` `[CONFIRMED: code]`.
 - Não há retries nem timeout explícitos no código `[CONFIRMED: ausência — code]`.
 
 ## Logging
 
-- `console.info`: início de execução, início/fim de ping com `elapsedMs`, fim da execução com status `[CONFIRMED: code]`.
+- `console.info`: início de execução, início/fim de cada ping com `elapsedMs`, fim da execução com status `[CONFIRMED: code]`.
 - `console.error`: falha de ping, falha de persistência, falha inesperada `[CONFIRMED: code]`.
 - Persistência estruturada em `background_job_executions` (ver [background-jobs.md](background-jobs.md)).
 
 ## Relação com background_job_executions
 
-Cada execução gera UMA linha na tabela do banco alvo, com `job_key = "keepalive"`, `environment = prod|dev`, `run_id` único, status e tempos — a coluna `status` usa o enum `background_job_status` (`success`/`failure`/`partial`; o keepalive só usa success/failure) `[CONFIRMED: code, database]`. Retenção de 365 dias via trigger `[CONFIRMED: migration]`.
+Cada execução gera DUAS linhas — uma por alvo, no banco de cada alvo — com `job_key = "keepalive"`, `environment = prod|dev`, MESMO `run_id` (agrupa a execução), status e tempos próprios — a coluna `status` usa o enum `background_job_status` (`success`/`failure`/`partial`; o keepalive só usa success/failure) `[CONFIRMED: code, database]`. Retenção de 365 dias via trigger `[CONFIRMED: migration]`.
 
 ## Testes
 
-`api/keepalive.test.ts` — unitário com mocks de `createClient` e `recordBackgroundJobExecution`; 4 cenários: ambiente prod (VERCEL_ENV=production), ambiente dev, persistência falha sem bloquear, erro principal → 500 `[CONFIRMED: test — api/keepalive.test.ts:51-164]`.
+`api/keepalive.test.ts` — unitário com mocks de `createClient` e `recordBackgroundJobExecution`; 5 cenários: dois alvos pingados/persistidos com mesmo runId, env dev ausente → 500, falha parcial (persistência por alvo + 500), falha de persistência não bloqueia, todos os alvos falham `[CONFIRMED: test — api/keepalive.test.ts]`.
 
 ## Evidências
 
 - E1 — Código completo: `api/keepalive.ts` `[CONFIRMED: code]`
 - E2 — Teste: `api/keepalive.test.ts` `[CONFIRMED: test]`
 - E3 — Cron e rewrite: `vercel.json` `[CONFIRMED: configuration]`
-- E4 — Histórico: `c9a385c` (implementação), `87aa0ff` (logging), `879a6c0` (environment-aware), `930de1b` (testes) `[CONFIRMED: git history]`
-- E5 — Divergência README × código (1 alvo × 2 bancos) RESOLVIDA — DEBT-0003 (2026-08-15) `[CONFIRMED: code × documentation]`
+- E4 — Histórico: `c9a385c` (implementação), `87aa0ff` (logging), `879a6c0` (regressão 1 alvo), `930de1b` (testes), DEBT-0006 (restauração multi-alvo) `[CONFIRMED: git history]`
+- E5 — Decisões DEBT-0006: OQ-1 (500 se qualquer alvo falhar) e endurecimento do alvo dev `[CONFIRMED: spec — proposed/technical-debt/DEBT-0006]`
 
 ## Veja também
 
 - [background-jobs.md](background-jobs.md), [overview.md](overview.md)
 - [../database/background_job_executions.md](../database/background_job_executions.md), [../database/triggers.md](../database/triggers.md)
 - [../security/secrets-and-environments.md](../security/secrets-and-environments.md)
+- [ADR-0007](../../decisions/ADR-0007-keepalive-cron-jobs.md)

--- a/.ai/specs/current/backend/background-jobs.md
+++ b/.ai/specs/current/backend/background-jobs.md
@@ -1,6 +1,6 @@
 # Background Jobs — Infraestrutura de execução
 
-**Última verificação:** 2026-08-13 (commit 6323664)
+**Última verificação:** 2026-08-23 (DEBT-0006)
 **Código:** `src/shared/background-jobs.ts` (+ tipos em `src/react-app/services/dtos/background-jobs.dto.ts`)
 
 ## Propósito
@@ -22,14 +22,14 @@ Infraestrutura reutilizável para registrar execuções de rotinas em background
 
 1. **Início:** o produtor gera `runId` (`crypto.randomUUID()` no keepalive) e mede `startedAt` `[CONFIRMED: code]`.
 2. **Execução:** a rotina roda seu trabalho (no keepalive: ping ao banco) `[CONFIRMED: code]`.
-3. **Persistência:** `recordBackgroundJobExecution` insere a linha; erro no INSERT lança `Error(message)` para o chamador decidir o tratamento (o keepalive loga e não bloqueia) `[CONFIRMED: code — background-jobs.ts:34-37; api/keepalive.ts:168-175]`.
+3. **Persistência:** `recordBackgroundJobExecution` insere a linha; erro no INSERT lança `Error(message)` para o chamador decidir o tratamento (o keepalive loga e não bloqueia) `[CONFIRMED: code — background-jobs.ts:34-37; api/keepalive.ts]`. No keepalive, uma execução gera **uma linha por alvo** (prod e dev), cada uma no banco do próprio alvo, com o mesmo `run_id` `[CONFIRMED: code — api/keepalive.ts]`.
 4. **Status:** `success` | `failure` | `partial` — o keepalive usa apenas success/failure; `partial` existe no enum/contrato mas sem produtor atual que o use `[CONFIRMED: code]`.
 5. **Retenção:** trigger `trg_trim_background_job_executions` remove linhas com mais de 365 dias a cada INSERT `[CONFIRMED: migration — ../database/triggers.md]`.
 6. **Consulta:** painel admin lê via RLS admin-only (Fase 5) `[CONFIRMED: database, code]`.
 
 ## Environment
 
-- O campo `environment` da linha (`prod`/`dev`) é informado pelo produtor — no keepalive, deriva de `VERCEL_ENV` `[CONFIRMED: code]`.
+- O campo `environment` da linha (`prod`/`dev`) é informado pelo produtor — no keepalive, cada execução cobre os DOIS ambientes (uma linha por alvo, mesmo `run_id`) `[CONFIRMED: code — api/keepalive.ts]`.
 - No frontend, o rótulo vem de `VITE_APP_ENVIRONMENT`/`import.meta.env.DEV` (`src/react-app/lib/app-environment.ts`) — usado para exibição/consultas `[CONFIRMED: code]`.
 
 ## Erros e observabilidade

--- a/.ai/specs/current/features/FEAT-0013-background-jobs.md
+++ b/.ai/specs/current/features/FEAT-0013-background-jobs.md
@@ -3,7 +3,7 @@
 **ID:** FEAT-0013
 **Tipo:** Current
 **Status:** Implementada
-**Última verificação:** 2026-08-15 (DEBT-0003)
+**Última verificação:** 2026-08-23 (DEBT-0006)
 
 ## Purpose
 
@@ -15,25 +15,25 @@ Infraestrutura server-side de rotinas em background com persistência centraliza
 
 ## Preconditions
 
-- Variáveis de ambiente do alvo (URL + service role) configuradas `[CONFIRMED: code — api/keepalive.ts:50-72]`
+- Variáveis de ambiente dos dois alvos (URL + service role) configuradas — prod com fallback, dev obrigatórias `[CONFIRMED: code — api/keepalive.ts]`
 
 ## Main Flow
 
 1. Cron `0 12 * * *` UTC aciona `/api/keepalive` (GET/HEAD) `[CONFIRMED: configuration — vercel.json]`.
-2. Ambiente resolvido por `VERCEL_ENV` → UM alvo (`meufenil` prod / `meufenil-dev`) `[CONFIRMED: code]`.
-3. Ping: service role faz `SELECT id FROM usuarios LIMIT 1` e mede duração `[CONFIRMED: code]`.
-4. Persistência via `recordBackgroundJobExecution` (`job_key="keepalive"`, run_id, environment, status, tempos, message, details) — falha de persistência loga e NÃO altera a resposta `[CONFIRMED: code]`.
-5. Resposta 200/500 com `{ok, runId, durationMs, projects:[projeto]}` `[CONFIRMED: code]`.
+2. DOIS alvos por execução, independente de `VERCEL_ENV`: prod (`meufenil`) e dev (`meufenil-dev`) `[CONFIRMED: code]`.
+3. Ping por alvo (service role, `SELECT id FROM usuarios LIMIT 1`, mede duração) em `Promise.allSettled` — falha de um alvo não impede o outro `[CONFIRMED: code]`.
+4. Persistência via `recordBackgroundJobExecution` por alvo (`job_key="keepalive"`, run_id MESMO para os dois, environment, status, tempos, message, details) — falha de persistência loga e NÃO altera a resposta `[CONFIRMED: code]`.
+5. Resposta 200 (ambos ok) / 500 (qualquer falha) com `{ok, runId, durationMs, projects:[prod, dev]}` `[CONFIRMED: code; decisão OQ-1 do DEBT-0006]`.
 6. Retenção: trigger remove execuções com mais de 365 dias a cada INSERT `[CONFIRMED: migration]`.
 
 ## Alternative Flows
 
-- Falha no ping → status 500 e registro com `status='failure'` `[CONFIRMED: code]`.
+- Falha no ping de um alvo → status 500 (se qualquer alvo falhou), persistência do alvo que falhou com `status='failure'` — o outro alvo continua `success` `[CONFIRMED: code]`.
 - Status `partial` existe no enum/contrato mas nenhum produtor o usa (fato) `[CONFIRMED: code]`.
 
 ## Error Flows
 
-- Env ausente → 500 `{ok:false, error}`; método inválido → 405 `[CONFIRMED: code]`.
+- Env ausente (inclui `KEEPALIVE_DEV_*` faltando) → 500 `{ok:false, error}`; método inválido → 405 `[CONFIRMED: code]`.
 
 ## Business Rules
 
@@ -57,7 +57,7 @@ Infraestrutura server-side de rotinas em background com persistência centraliza
 
 ## Tests
 
-- `api/keepalive.test.ts` (4), `src/shared/background-jobs.test.ts` (3)
+- `api/keepalive.test.ts` (5), `src/shared/background-jobs.test.ts` (3)
 - **Coverage status:** PARTIALLY TESTED (trigger de retenção sem teste; execução real não verificada em E2E)
 
 ## Dependencies
@@ -72,7 +72,7 @@ Infraestrutura server-side de rotinas em background com persistência centraliza
 
 - E1 — `api/keepalive.ts`, `src/shared/background-jobs.ts` `[CONFIRMED: code]`
 - E2 — Migration 20260807 + vercel.json `[CONFIRMED: migration, configuration]`
-- E3 — Divergência README × código (1 alvo por execução) RESOLVIDA — DEBT-0003 (2026-08-15) `[CONFIRMED: code × documentation]`
+- E3 — Regressão "1 alvo por execução" (`879a6c0`, 2026-08-11) corrigida — DEBT-0006 (2026-08-23) restaurou o multi-alvo; o DEBT-0003 (2026-08-15) havia codificado o drift 1-alvo na documentação `[CONFIRMED: git, code × documentation]`
 
 ## Unknowns
 

--- a/.ai/specs/current/security/secrets-and-environments.md
+++ b/.ai/specs/current/security/secrets-and-environments.md
@@ -1,6 +1,6 @@
 # Secrets e Ambientes — MeuFenil
 
-**Última verificação:** 2026-08-15 (DEBT-0003)
+**Última verificação:** 2026-08-23 (DEBT-0006)
 
 > ⚠️ Este documento registra SOMENTE nomes, finalidade, escopo e localização das variáveis. **Nenhum valor real de secret é documentado.**
 
@@ -36,11 +36,11 @@
 |---|---|---|
 | `VERCEL_ENV` | decide ambiente do keepalive (`production` → `prod`; caso contrário `dev`) | `api/keepalive.ts` |
 | `KEEPALIVE_SUPABASE_URL` / `KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY` | credenciais do alvo PROD (override explícito) | `api/keepalive.ts` |
-| `KEEPALIVE_DEV_SUPABASE_URL` / `KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY` | credenciais do alvo DEV | `api/keepalive.ts` |
+| `KEEPALIVE_DEV_SUPABASE_URL` / `KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY` | credenciais do alvo DEV — **obrigatórias, sem fallback** (DEBT-0006) | `api/keepalive.ts` |
 | `VITE_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` | fallback (a rota aceita como fallback) | `api/keepalive.ts`, README.md |
 | `SUPABASE_URL` | fallback adicional na resolução | `api/keepalive.ts` |
 
-O keepalive conecta em UM banco por execução — o do ambiente resolvido por `VERCEL_ENV` (prod → `meufenil`; caso contrário → `meufenil-dev`) — usando service role, e grava a execução em `background_job_executions` do banco alvo `[CONFIRMED: code — api/keepalive.ts:46-72]`. (A descrição anterior de acesso aos DOIS ambientes era drift — corrigido pelo DEBT-0003, 2026-08-15.)
+O keepalive conecta nos DOIS bancos por execução (prod `meufenil` e dev `meufenil-dev`), usando service role, e grava uma linha em `background_job_executions` de cada banco com o mesmo `run_id` `[CONFIRMED: code — api/keepalive.ts]`. O alvo dev exige `KEEPALIVE_DEV_*` sem fallback (endurecido pelo DEBT-0006, 2026-08-23). (Histórico: entre 2026-08-11 e 2026-08-23 o código executava 1 alvo por execução — regressão `879a6c0` corrigida pelo DEBT-0006; o DEBT-0003, 2026-08-15, havia codificado o drift na documentação.)
 
 ### Edge Functions (Supabase/Deno — `Deno.env`)
 
@@ -77,7 +77,7 @@ O keepalive conecta em UM banco por execução — o do ambiente resolvido por `
 
 | Local | Modo de uso |
 |---|---|
-| `api/keepalive.ts` | service role para leitura de `usuarios` + escrita em `background_job_executions` no banco do ambiente da execução (1 alvo por execução) |
+| `api/keepalive.ts` | service role para leitura de `usuarios` + escrita em `background_job_executions` nos DOIS bancos por execução (prod e dev, mesmo `run_id`) |
 | `supabase/functions/delegar-acesso/index.ts` | validação de token (`auth.getUser`), escrita em `delegacoes_acesso`, consultas de `usuarios` (bypass de RLS) |
 | `supabase/functions/delete-account/index.ts` | exclusão de `registros`, `usuarios` e `auth.admin.deleteUser` |
 | `src/shared/security/*.test.ts` (+ `test-helpers.ts`) | criação de usuários de teste e validação com JWTs reais |

--- a/.ai/specs/decisions/ADR-0007-keepalive-cron-jobs.md
+++ b/.ai/specs/decisions/ADR-0007-keepalive-cron-jobs.md
@@ -26,7 +26,7 @@ DOCUMENTED — README.md ("Keepalive diário" e "Infraestrutura de jobs") + comm
 
 ## Consequences (OBSERVED)
 
-1. Um alvo por execução (ambiente atual), apesar do README descrever acesso aos dois bancos — drift documentado `[CONFIRMED: code × documentation — Fase 4]`.
+1. Cada execução mantém os DOIS alvos (prod e dev) com o mesmo `run_id` — comportamento original, restaurado pelo DEBT-0006 (2026-08-23) após a regressão `879a6c0` (2026-08-11, release v1.6.0) ter limitado a 1 alvo por execução `[CONFIRMED: code — api/keepalive.ts; git]`.
 2. Falha de persistência não bloqueia a resposta do keepalive `[CONFIRMED: code]`.
 3. Leitura das execuções restrita a admins (RLS) `[CONFIRMED: database]`.
 4. Retenção automática de 365 dias a cada INSERT `[CONFIRMED: migration]`.
@@ -39,3 +39,4 @@ Não determinadas a partir das evidências disponíveis.
 ## Related Specs
 
 - [../current/backend/api-keepalive.md](../current/backend/api-keepalive.md), [../current/backend/background-jobs.md](../current/backend/background-jobs.md), [../current/database/background_job_executions.md](../current/database/background_job_executions.md), [../current/features/FEAT-0013-background-jobs.md](../current/features/FEAT-0013-background-jobs.md)
+- [DEBT-0006 — Restaurar keepalive do ambiente dev (regressão 879a6c0)](../../proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md)

--- a/.ai/specs/proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md
+++ b/.ai/specs/proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md
@@ -1,10 +1,12 @@
 # DEBT-0006 — Restaurar keepalive do ambiente dev (regressão 879a6c0)
 
 **Type:** DEBT
-**Status:** PROPOSED
+**Status:** ACCEPTED
 **Title:** Restaurar keepalive do ambiente dev (regressão 879a6c0)
 **Issue:** #40
 **Created on:** 2026-08-23
+**Approved by:** Lucas Martins Menezes
+**Approved on:** 2026-08-23
 
 ## Problem
 
@@ -18,14 +20,14 @@ O keepalive (Vercel Cron → `/api/keepalive`) deixou de registrar execuções n
 - **Antes de `879a6c0`** (até 2026-08-10), o handler pingava **os dois alvos em toda execução** (`targets = [meufenil (prod), meufenil-dev (dev)]` com `Promise.allSettled`), persistindo prod e dev com o mesmo `runId` `[CONFIRMED: git — api/keepalive.ts@879a6c0^]`.
 - **`879a6c0`** (2026-08-11, "feat(jobs): add environment-aware monitoring", incluído no release v1.6.0) trocou o multi-alvo por alvo único resolvido por `VERCEL_ENV` `[CONFIRMED: git — diff api/keepalive.ts]`.
 - A invocação do cron chega ao deployment de **produção** (`environment: production`, `branch: master` — logs Vercel 2026-08-23) `[CONFIRMED: logs do usuário]`; logo, `VERCEL_ENV=production` → o alvo dev é **inalcançável pelo cron** `[INFERRED — Basis: em execução de produção o código resolve sempre `prod`; a ausência de linhas dev desde 2026-08-11 corrobora que o cron não atinge o caminho dev]`.
-- Banco dev sem novas linhas em `background_job_executions` (`environment = 'dev'`) desde 2026-08-11 — mesmo dia do commit `[relato do usuário — draft 003; confirmação direta via consulta sugerida no AC-3]`.
+- Banco dev sem novas linhas em `background_job_executions` (`environment = 'dev'`) desde 2026-08-11 — mesmo dia do commit `[CONFIRMED: consulta direta via CLI local em 2026-08-23 — última linha dev em 2026-08-11T12:38:35, total de 6 linhas]`.
 - Sem commits em `api/keepalive.ts`, `src/shared/background-jobs.ts` ou `vercel.json` entre 2026-08-05 e 2026-08-20 `[CONFIRMED: git]`.
 - Env vars dev (`KEEPALIVE_DEV_SUPABASE_URL`/`KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY`) **existem e estão válidas** no painel Vercel `[CONFIRMED: usuário — 2026-08-23]` — elimina causa raiz de configuração de painel.
 - Documentação atual documenta "1 alvo por execução" como comportamento vigente (README corrigido pelo [DEBT-0003](../../archive/implemented/technical-debt/DEBT-0003-atualizar-readme.md) e `api-keepalive.md`) — ou seja, codifica a regressão como especificação `[CONFIRMED: docs — README.md, current/backend/api-keepalive.md]`.
 
 ## Proposed State
 
-O keepalive volta a manter **ambos os ambientes**: cada execução do cron (em produção) pinga e persiste em prod **e** dev, como no comportamento pré-`879a6c0`, com a documentação sincronizada e testes cobrindo o multi-alvo. A semântica de resposta e o mecanismo exato são decisão humana (ver **Decision** e **Open Questions**).
+O keepalive volta a manter **ambos os ambientes**: cada execução do cron (em produção) pinga e persiste em prod **e** dev, como no comportamento pré-`879a6c0`, com a documentação sincronizada e testes cobrindo o multi-alvo. Resposta `500` se qualquer alvo falhar (OQ-1); alvo dev com resolução endurecida (exige `KEEPALIVE_DEV_*`, sem fallback para vars de prod) — ver **Decision**.
 
 ## Motivation
 
@@ -83,7 +85,7 @@ Nenhuma.
 ## Risks
 
 - **Semântica de resposta com multi-alvo:** falha em um alvo deve ou não tornar a resposta 500? (comportamento pré-`879a6c0`: `ok = projects.every(...)` — 500 se qualquer alvo falhar) — decisão registrada em Open Questions.
-- **Fallback de env perigoso (latente):** se `KEEPALIVE_DEV_*` forem removidas no futuro, o fallback (`VITE_SUPABASE_URL`/`SUPABASE_URL`) aponta para **prod** — uma execução "dev" pingaria prod e gravaria `environment = 'dev'` no banco de produção `[CONFIRMED: code — api/keepalive.ts:66-71]`. Recomenda-se manter as vars dev preenchidas (estado atual) e, em implementação, considerar endurecer a resolução `[sugestão — decisão de implementação]`.
+- **Fallback de env perigoso (latente):** se `KEEPALIVE_DEV_*` forem removidas no futuro, o fallback (`VITE_SUPABASE_URL`/`SUPABASE_URL`) aponta para **prod** — uma execução "dev" pingaria prod e gravaria `environment = 'dev'` no banco de produção. **MITIGADO na aprovação (2026-08-23):** a resolução do alvo dev foi endurecida — exige `KEEPALIVE_DEV_*` (throw se ausentes), sem fallback para vars de prod; conseqüência: execuções em deployments sem as vars dev retornam `500` explícito em vez de poluir o banco errado.
 - **Projeto Supabase dev possivelmente inativo:** sem keepalive desde 2026-08-11, o projeto dev pode ter entrado em estado de pausa por inatividade; primeira execução pós-fix pode falhar até reativação manual `[ASSUMED]`.
 - **Exposição de secrets:** a execução em produção carrega as duas service role keys (prod e dev) — mesmo estado de exposição do período pré-`879a6c0`, sem agravamento `[CONFIRMED: code — api/keepalive.ts]`.
 
@@ -94,13 +96,13 @@ Nenhuma.
 3. **Disparo externo agendado (ex.: GitHub Actions / serviço externo) chamando a URL do deployment dev:** adiciona peça de infraestrutura fora da Vercel; o deployment dev precisa de URL estável.
 4. **Manter o status quo (1 alvo por execução):** dev permanece sem keepalive — contraria o objetivo da proposta (não recomendado).
 
-**Decision:** TBD — a escolha é humana. A direção indicada pelo usuário (Alternativa 1) deve ser registrada com **Approved by/on:** na aprovação.
+**Decision:** Alternativa 1 — multi-alvo por execução (restauração do comportamento pré-`879a6c0`, com endurecimento). Detalhes decididos na aprovação (2026-08-23): (i) OQ-1 → resposta `500` se qualquer alvo falhar (`projects.every`, comportamento pré-`879a6c0`); (ii) alvo dev exige `KEEPALIVE_DEV_SUPABASE_URL`/`KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY` sem fallback para vars de prod (Risks — endurecimento). **Approved by:** Lucas Martins Menezes · **Approved on:** 2026-08-23
 
 ## Open Questions
 
-1. **Semântica de resposta com multi-alvo:** com falha parcial (um alvo ok, outro não), a resposta deve ser 200, 500 ou com corpo indicando o estado por alvo? (pré-`879a6c0`: 500 se qualquer alvo falhar — `projects.every`)
-2. **Estado do projeto Supabase dev:** está ativo (não pausado por inatividade)? Verificação operacional pré-validação do AC-1.
-3. **Confirmação da observação:** consulta ao banco dev (`SELECT` em `background_job_executions` com `environment = 'dev'` e `started_at >= 2026-08-11`) para evidenciar formalmente a ausência de execuções — evidência forte para a Issue/PR.
+1. **Semântica de resposta com multi-alvo:** com falha parcial (um alvo ok, outro não), a resposta deve ser 200, 500 ou com corpo indicando o estado por alvo? **RESOLVIDA (2026-08-23, autor):** `500` se qualquer alvo falhar (`projects.every` — comportamento pré-`879a6c0`); persistência por alvo permanece independente da resposta (AC-4).
+2. **Estado do projeto Supabase dev:** está ativo (não pausado por inatividade)? **RESOLVIDA (2026-08-23):** projeto dev ATIVO — respondeu à consulta de leitura via CLI local (SELECT em `background_job_executions`), não está pausado.
+3. **Confirmação da observação:** consulta ao banco dev (`SELECT` em `background_job_executions` com `environment = 'dev'` e `started_at >= 2026-08-11`) para evidenciar formalmente a ausência de execuções — evidência forte para a Issue/PR. **RESOLVIDA (2026-08-23):** consulta direta confirma ausência desde `2026-08-11T12:38:35` (última linha dev; tabela dev com 6 linhas no total); prod continua com execuções regulares `success` (ex.: 2026-08-23T12:14, 2026-08-22) — evidência anexada à Issue/PR.
 
 ## Acceptance Criteria
 

--- a/.ai/specs/proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md
+++ b/.ai/specs/proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md
@@ -1,7 +1,7 @@
 # DEBT-0006 — Restaurar keepalive do ambiente dev (regressão 879a6c0)
 
 **Type:** DEBT
-**Status:** ACCEPTED
+**Status:** IMPLEMENTATION
 **Title:** Restaurar keepalive do ambiente dev (regressão 879a6c0)
 **Issue:** #40
 **Created on:** 2026-08-23

--- a/README.md
+++ b/README.md
@@ -142,21 +142,23 @@ Caso o volume de usuários cresça a ponto de exigir planos pagos para manter a 
 
 Para evitar que o projeto gratuito do Supabase entre em estado de pausa por inatividade, a aplicação expõe uma rota interna em `/api/keepalive`.
 
-Essa rota é executada automaticamente pelo Vercel Cron uma vez por dia e faz uma leitura mínima na tabela `public.usuarios` do banco correspondente ao ambiente atual:
+Essa rota é executada automaticamente pelo Vercel Cron uma vez por dia e, em cada execução, faz uma leitura mínima na tabela `public.usuarios` dos **dois** bancos:
 
-- em desenvolvimento, lê o banco de dev
-- em produção, lê o banco de produção
+- banco de produção (label `meufenil`)
+- banco de dev (label `meufenil-dev`)
 
-Cada execução também persiste um histórico próprio na tabela `public.background_job_executions` do mesmo banco acessado.
+Cada execução também persiste um histórico próprio na tabela `public.background_job_executions` de cada banco acessado, com o mesmo `run_id` para os dois alvos.
 
-A rota usa automaticamente as credenciais do ambiente atual:
+As credenciais vêm de variáveis explícitas no painel da Vercel:
 
 ```env
-VITE_SUPABASE_URL=...
-SUPABASE_SERVICE_ROLE_KEY=...
+KEEPALIVE_SUPABASE_URL=...
+KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY=...
+KEEPALIVE_DEV_SUPABASE_URL=...
+KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
-Se você já mantiver variáveis explícitas de keepalive no painel da Vercel, elas continuam funcionando como override, mas não são obrigatórias para o fluxo padrão.
+O alvo de produção aceita fallback para `VITE_SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` (e `SUPABASE_URL`). O alvo de dev **exige** as próprias variáveis `KEEPALIVE_DEV_*` — sem fallback, para que uma falha de configuração nunca grave registros de "dev" no banco de produção.
 
 Horário do cron:
 
@@ -194,12 +196,14 @@ Monitoramento no painel administrativo:
 - a tela inclui filtros por job, status e período
 - o histórico fica paginado e protegido por RLS, visível apenas para administradores
 
-Para testar manualmente (cada execução acessa apenas o banco do ambiente resolvido — em execução local, `VERCEL_ENV` não é `production`, então o alvo é o banco de dev):
+Para testar manualmente (cada execução acessa os dois alvos — em execução local, aponte os dois pares de variáveis para o ambiente de teste):
 
 ```bash
 # carregue o arquivo do ambiente e crie aliases temporários para o keepalive
 set -a
 source .env.development
+export KEEPALIVE_SUPABASE_URL="$VITE_SUPABASE_URL"
+export KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY"
 export KEEPALIVE_DEV_SUPABASE_URL="$VITE_SUPABASE_URL"
 export KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY"
 set +a
@@ -208,9 +212,9 @@ vercel dev
 curl http://localhost:3000/api/keepalive
 ```
 
-Na Vercel (produção), o alvo é o banco de produção, com `KEEPALIVE_SUPABASE_URL`/`KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY` — ou o fallback automático já descrito acima.
+Na Vercel (produção), o alvo de produção usa `KEEPALIVE_SUPABASE_URL`/`KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY` (ou o fallback para `VITE_SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`) e o alvo de dev usa `KEEPALIVE_DEV_SUPABASE_URL`/`KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY`.
 
-A resposta `200` indica que o banco-alvo foi acessado com sucesso. Se a leitura falhar, a rota retorna `500` e o payload indica o erro.
+A resposta `200` indica que os dois bancos foram acessados com sucesso. Se algum alvo falhar, a rota retorna `500` e o payload (`projects`) mostra qual banco apresentou erro — o alvo que funcionou é persistido mesmo assim.
 
 Para consultar o histórico:
 

--- a/api/keepalive.test.ts
+++ b/api/keepalive.test.ts
@@ -33,8 +33,13 @@ function createResponse(): MockResponse {
   };
 }
 
-function prepareClient(result: { error: null } | { error: { message: string } }) {
-  const limitMock = vi.fn().mockResolvedValue(result);
+function prepareClient(
+  results: Array<{ error: null } | { error: { message: string } }>
+) {
+  const limitMock = vi.fn();
+  for (const result of results) {
+    limitMock.mockResolvedValueOnce(result);
+  }
   const selectMock = vi.fn(() => ({ limit: limitMock }));
   const fromMock = vi.fn(() => ({ select: selectMock }));
 
@@ -59,15 +64,27 @@ describe("keepalive handler", () => {
     delete process.env.KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY;
     delete process.env.KEEPALIVE_DEV_SUPABASE_URL;
     delete process.env.KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.VITE_SUPABASE_URL;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
   });
 
-  it("usa o ambiente de produção quando VERCEL_ENV é production", async () => {
-    process.env.VERCEL_ENV = "production";
+  function setProdEnv() {
     process.env.KEEPALIVE_SUPABASE_URL = "https://prod.example.supabase.co";
     process.env.KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY = "prod-key";
+  }
 
-    const { fromMock } = prepareClient({ error: null });
-    recordMock.mockResolvedValueOnce(undefined);
+  function setDevEnv() {
+    process.env.KEEPALIVE_DEV_SUPABASE_URL = "https://dev.example.supabase.co";
+    process.env.KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY = "dev-key";
+  }
+
+  it("pinga e persiste nos dois alvos (prod e dev) com o mesmo runId", async () => {
+    setProdEnv();
+    setDevEnv();
+
+    prepareClient([{ error: null }, { error: null }]);
+    recordMock.mockResolvedValue(undefined);
 
     const res = createResponse();
     await handler({ method: "GET" }, res);
@@ -79,83 +96,43 @@ describe("keepalive handler", () => {
         auth: { autoRefreshToken: false, persistSession: false },
       }),
     );
-    expect(fromMock).toHaveBeenCalledWith("usuarios");
-    expect(recordMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        jobKey: "keepalive",
-        environment: "prod",
-        status: "success",
-      }),
-    );
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual(
-      expect.objectContaining({
-        ok: true,
-        projects: [expect.objectContaining({ environment: "prod", ok: true })],
-      }),
-    );
-  });
-
-  it("usa o ambiente de desenvolvimento quando não está em produção", async () => {
-    process.env.VERCEL_ENV = "preview";
-    process.env.KEEPALIVE_DEV_SUPABASE_URL = "https://dev.example.supabase.co";
-    process.env.KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY = "dev-key";
-
-    const { fromMock } = prepareClient({ error: null });
-    recordMock.mockResolvedValueOnce(undefined);
-
-    const res = createResponse();
-    await handler({ method: "GET" }, res);
-
     expect(createClientMock).toHaveBeenCalledWith(
       "https://dev.example.supabase.co",
       "dev-key",
-      expect.any(Object),
-    );
-    expect(fromMock).toHaveBeenCalledWith("usuarios");
-    expect(recordMock).toHaveBeenCalledWith(
-      expect.anything(),
       expect.objectContaining({
-        environment: "dev",
-        status: "success",
+        auth: { autoRefreshToken: false, persistSession: false },
       }),
     );
-    expect(JSON.parse(res.body)).toEqual(
-      expect.objectContaining({
-        ok: true,
-        projects: [expect.objectContaining({ environment: "dev", ok: true })],
-      }),
-    );
-  });
 
-  it("não bloqueia o keepalive se a persistência do log falhar", async () => {
-    process.env.VERCEL_ENV = "production";
-    process.env.KEEPALIVE_SUPABASE_URL = "https://prod.example.supabase.co";
-    process.env.KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY = "prod-key";
+    const calls = recordMock.mock.calls.map(([, input]) => input);
+    const prodCall = calls.find((input) => input.environment === "prod");
+    const devCall = calls.find((input) => input.environment === "dev");
 
-    prepareClient({ error: null });
-    recordMock.mockRejectedValueOnce(new Error("persistência falhou"));
-
-    const res = createResponse();
-    await handler({ method: "GET" }, res);
+    expect(prodCall).toMatchObject({
+      jobKey: "keepalive",
+      environment: "prod",
+      status: "success",
+    });
+    expect(devCall).toMatchObject({
+      jobKey: "keepalive",
+      environment: "dev",
+      status: "success",
+    });
+    expect(prodCall.runId).toBe(devCall.runId);
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual(
-      expect.objectContaining({
-        ok: true,
-        projects: [expect.objectContaining({ environment: "prod", ok: true })],
-      }),
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.projects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ environment: "prod", ok: true }),
+        expect.objectContaining({ environment: "dev", ok: true }),
+      ]),
     );
   });
 
-  it("retorna erro quando a leitura principal falha", async () => {
-    process.env.VERCEL_ENV = "production";
-    process.env.KEEPALIVE_SUPABASE_URL = "https://prod.example.supabase.co";
-    process.env.KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY = "prod-key";
-
-    prepareClient({ error: { message: "timeout" } });
-    recordMock.mockResolvedValueOnce(undefined);
+  it("retorna 500 com erro explícito quando as variáveis do alvo dev estão ausentes", async () => {
+    setProdEnv();
 
     const res = createResponse();
     await handler({ method: "GET" }, res);
@@ -164,8 +141,84 @@ describe("keepalive handler", () => {
     expect(JSON.parse(res.body)).toEqual(
       expect.objectContaining({
         ok: false,
-        projects: [expect.objectContaining({ ok: false, error: "timeout" })],
+        error: "Missing environment variable: KEEPALIVE_DEV_SUPABASE_URL",
       }),
     );
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it("falha parcial: alvo dev falha, prod persiste; resposta 500", async () => {
+    setProdEnv();
+    setDevEnv();
+
+    prepareClient([{ error: null }, { error: { message: "timeout" } }]);
+    recordMock.mockResolvedValue(undefined);
+
+    const res = createResponse();
+    await handler({ method: "GET" }, res);
+
+    expect(res.statusCode).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.projects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ environment: "prod", ok: true }),
+        expect.objectContaining({ environment: "dev", ok: false, error: "timeout" }),
+      ]),
+    );
+
+    const calls = recordMock.mock.calls.map(([, input]) => input);
+    const prodCall = calls.find((input) => input.environment === "prod");
+    const devCall = calls.find((input) => input.environment === "dev");
+
+    expect(prodCall).toMatchObject({ status: "success" });
+    expect(devCall).toMatchObject({ status: "failure" });
+    expect(prodCall.runId).toBe(devCall.runId);
+  });
+
+  it("falha na persistência de um alvo não bloqueia a resposta", async () => {
+    setProdEnv();
+    setDevEnv();
+
+    prepareClient([{ error: null }, { error: null }]);
+    recordMock.mockRejectedValueOnce(new Error("persistência falhou"));
+    recordMock.mockResolvedValueOnce(undefined);
+
+    const res = createResponse();
+    await handler({ method: "GET" }, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(
+      expect.objectContaining({
+        ok: true,
+        projects: [
+          expect.objectContaining({ environment: "prod", ok: true }),
+          expect.objectContaining({ environment: "dev", ok: true }),
+        ],
+      }),
+    );
+  });
+
+  it("todos os alvos falham → resposta 500 e persistência failure nos dois", async () => {
+    setProdEnv();
+    setDevEnv();
+
+    prepareClient([
+      { error: { message: "timeout" } },
+      { error: { message: "denied" } },
+    ]);
+    recordMock.mockResolvedValue(undefined);
+
+    const res = createResponse();
+    await handler({ method: "GET" }, res);
+
+    expect(res.statusCode).toBe(500);
+    const calls = recordMock.mock.calls.map(([, input]) => input);
+    expect(calls.find((input) => input.environment === "prod")).toMatchObject({
+      status: "failure",
+    });
+    expect(calls.find((input) => input.environment === "dev")).toMatchObject({
+      status: "failure",
+    });
   });
 });

--- a/api/keepalive.ts
+++ b/api/keepalive.ts
@@ -43,32 +43,27 @@ function requireEnv(...names: string[]): string {
   throw new Error(`Missing environment variable: ${names.join(" or ")}`);
 }
 
-function resolveKeepaliveEnvironment(): "prod" | "dev" {
-  return process.env.VERCEL_ENV === "production" ? "prod" : "dev";
-}
-
-function resolveKeepaliveTarget(environment: "prod" | "dev"): KeepaliveTarget {
-  if (environment === "prod") {
-    return {
+function resolveKeepaliveTargets(): KeepaliveTarget[] {
+  return [
+    {
       label: "meufenil",
-      environment,
+      environment: "prod",
       url: requireEnv("KEEPALIVE_SUPABASE_URL", "VITE_SUPABASE_URL", "SUPABASE_URL"),
       serviceRoleKey: requireEnv(
         "KEEPALIVE_SUPABASE_SERVICE_ROLE_KEY",
         "SUPABASE_SERVICE_ROLE_KEY"
       ),
-    };
-  }
-
-  return {
-    label: "meufenil-dev",
-    environment,
-    url: requireEnv("KEEPALIVE_DEV_SUPABASE_URL", "VITE_SUPABASE_URL", "SUPABASE_URL"),
-    serviceRoleKey: requireEnv(
-      "KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY",
-      "SUPABASE_SERVICE_ROLE_KEY"
-    ),
-  };
+    },
+    {
+      label: "meufenil-dev",
+      environment: "dev",
+      // DEBT-0006: o alvo dev exige as próprias variáveis, sem fallback para vars de
+      // produção — VITE_SUPABASE_URL/SUPABASE_URL apontam para o banco de prod e
+      // gravariam linhas environment='dev' no banco errado.
+      url: requireEnv("KEEPALIVE_DEV_SUPABASE_URL"),
+      serviceRoleKey: requireEnv("KEEPALIVE_DEV_SUPABASE_SERVICE_ROLE_KEY"),
+    },
+  ];
 }
 
 function createSupabaseClient(url: string, serviceRoleKey: string) {
@@ -157,24 +152,69 @@ export default async function handler(req: KeepaliveRequest, res: KeepaliveRespo
 
     const startedAt = Date.now();
     const runId = crypto.randomUUID();
-    const environment = resolveKeepaliveEnvironment();
-    const target = resolveKeepaliveTarget(environment);
+    const targets = resolveKeepaliveTargets();
 
     console.info("[keepalive] run started");
 
-    const project = await pingProject(target);
-    const logClient = createSupabaseClient(target.url, target.serviceRoleKey);
+    const results = await Promise.allSettled(
+      targets.map((target) => pingProject(target))
+    );
+    const projects = results.map((result, index) => {
+      const fallbackTarget = targets[index];
+      const fallbackStartedAt = new Date(startedAt).toISOString();
+      const fallbackFinishedAt = new Date().toISOString();
 
-    try {
-      await persistProjectExecution(logClient, runId, project);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      if (result.status === "fulfilled") {
+        return result.value;
+      }
+
+      const errorMessage =
+        result.reason instanceof Error
+          ? result.reason.message
+          : String(result.reason);
+
       console.error(
-        `[keepalive] failed to persist ${project.environment} result: ${message}`
+        `[keepalive] failed ${fallbackTarget.label} before query: ${errorMessage}`
       );
-    }
 
-    const ok = project.ok;
+      return {
+        label: fallbackTarget.label,
+        environment: fallbackTarget.environment,
+        ok: false,
+        elapsedMs: 0,
+        startedAt: fallbackStartedAt,
+        finishedAt: fallbackFinishedAt,
+        error: errorMessage,
+      };
+    });
+
+    await Promise.all(
+      projects.map(async (project) => {
+        const target = targets.find(
+          (item) => item.environment === project.environment
+        );
+
+        if (!target) {
+          console.error(
+            `[keepalive] missing target for environment ${project.environment}`
+          );
+          return;
+        }
+
+        const logClient = createSupabaseClient(target.url, target.serviceRoleKey);
+
+        try {
+          await persistProjectExecution(logClient, runId, project);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(
+            `[keepalive] failed to persist ${project.environment} result: ${message}`
+          );
+        }
+      })
+    );
+
+    const ok = projects.every((project) => project.ok);
     const durationMs = Date.now() - startedAt;
 
     console.info(
@@ -189,7 +229,7 @@ export default async function handler(req: KeepaliveRequest, res: KeepaliveRespo
         ok,
         runId,
         durationMs,
-        projects: [project],
+        projects,
       })
     );
   } catch (error) {


### PR DESCRIPTION
**Spec:** DEBT-0006 — Restaurar keepalive do ambiente dev (regressão 879a6c0) — [spec](.ai/specs/proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md)
**Issue:** Part of #40 (nunca "Closes" — Issue canônica)
**Tipo:** DEBT
**Autorização:** Decision aprovada por Lucas Martins Menezes em 2026-08-23

## O que muda

Restauração do multi-alvo no handler `api/keepalive.ts` — cada execução do cron pinga e persiste em prod e dev com o mesmo runId (`Promise.allSettled`); resposta 500 se qualquer alvo falhar; alvo dev endurecido (exige `KEEPALIVE_DEV_*` sem fallback para vars de prod — evita gravar `environment='dev'` no banco de produção); removida a resolução por `VERCEL_ENV`; sem migrations; `vercel.json` inalterado.

## Evidências de validação (por AC)

- AC-1 (prod+dev mesmo runId): teste unitário "pinga e persiste nos dois alvos com o mesmo runId" (`api/keepalive.test.ts`); validação operacional pendente: próximo cron 2026-08-24 12:00 UTC
- AC-2 (dev volta a receber execuções): evidência de base — banco dev sem execuções desde 2026-08-11T12:38:35 (consulta via CLI local em 2026-08-23, 6 linhas na tabela); validação operacional pós-deploy
- AC-3 (prod sem regressão): evidência de base — execuções prod regulares `success` (2026-08-23T12:14, 2026-08-22, ...)
- AC-4 (falha parcial não impede persistência do outro; resposta conforme OQ-1): testes "falha parcial" e "falha na persistência não bloqueia"
- AC-5 (testes multi-alvo): 5 cenários novos em `api/keepalive.test.ts`
- AC-6 (docs no mesmo commit): README, `current/backend/api-keepalive.md`, `current/backend/background-jobs.md`, `current/security/secrets-and-environments.md`, `current/features/FEAT-0013-background-jobs.md`, `decisions/ADR-0007` (Consequence 1)

## Testes

- `npx vitest run` → 45 arquivos / 324 testes passando
- `tsc -b` limpo
- eslint dos arquivos alterados limpo (erros de lint restantes são pré-existentes em arquivos não tocados)

## Segurança

Sem mudança de schema/RLS/RPC; exposição de secrets inalterada (mesmo estado pré-879a6c0); env dev ausente agora falha explícito em vez de poluir o banco de produção (mitigação de risco documentada na spec).

## Checklist

- [x] ACs validadas com evidência (acima; operacionais pendentes listadas)
- [x] Current Specs sincronizadas (matriz CONVENTIONS §11 — listar arquivos: README, `current/backend/api-keepalive.md`, `current/backend/background-jobs.md`, `current/security/secrets-and-environments.md`, `current/features/FEAT-0013-background-jobs.md`, `decisions/ADR-0007`)
- [x] Testes: `npx vitest run` → 45 arquivos / 324 testes; `tsc -b` limpo; eslint limpo
- [x] Sem mudança HIGH sem autorização explícita (autorização na spec `proposed/technical-debt/DEBT-0006-restaurar-keepalive-dev.md` — Decision 2026-08-23)
- [ ] Merge: aguardando aprovação humana do PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
