### PR TITLE
feat(feat-0017): M3 — motor puro de sincronização de referências (canonical/compare/engine)

### DIFF
--- a/src/shared/referencias-sync/canonical.test.ts
+++ b/src/shared/referencias-sync/canonical.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { chaveFenil, chaveMarca, chaveNome, chaveNomeMarca, chaveRef } from "./canonical";
+
+/**
+ * Chave canônica (§7.1/§7.2) — espelho do UNIQUE parcial do banco
+ * `lower(trim(both from nome)), lower(trim(both from marca)), fenil
+ * numeric(10,1)` (ENH-0004): "igual no motor" ≡ "igual no índice".
+ */
+
+function item(nome: string, marca = "", fenil = 100) {
+  return { nome, marca, fenil_mg_por_100g: fenil };
+}
+
+describe("chaveNome", () => {
+  it("lower(trim) — espaço em volta e caixa são irrelevantes", () => {
+    expect(chaveNome("  Arroz  ")).toBe("arroz");
+    expect(chaveNome("ARROZ")).toBe("arroz");
+    expect(chaveNome(" arroz ")).toBe("arroz");
+  });
+
+  it("preserva acentuação (lowercase não remove diacríticos)", () => {
+    expect(chaveNome("Feijão")).toBe("feijão");
+    expect(chaveNome("FEIJÃO")).toBe("feijão");
+  });
+});
+
+describe("chaveMarca", () => {
+  it("espelho de VARIANTES_SEM_MARCA (react-app) → ''", () => {
+    expect(chaveMarca("")).toBe("");
+    expect(chaveMarca("  ")).toBe("");
+    expect(chaveMarca("não se aplica/produto in natura")).toBe("");
+    expect(chaveMarca("nao se aplica/produto in natura")).toBe("");
+    expect(chaveMarca("não se aplica (produto in natura)")).toBe("");
+    expect(chaveMarca("nao se aplica (produto in natura)")).toBe("");
+  });
+
+  it("case/trim irrelevantes nas variantes", () => {
+    expect(chaveMarca("  PRODUTO IN NATURA ")).toBe("");
+    expect(chaveMarca("NÃO SE APLICA/PRODUTO IN NATURA")).toBe("");
+    expect(chaveMarca("Produto in natura")).toBe("");
+  });
+
+  it("'produto in natura' (extensão §7.2) → ''", () => {
+    expect(chaveMarca("Produto In Natura")).toBe("");
+    expect(chaveMarca("PRODUTO IN NATURA")).toBe("");
+  });
+
+  it("marca real é preservada (lower(trim) apenas)", () => {
+    expect(chaveMarca("Marca A")).toBe("marca a");
+    expect(chaveMarca("Sem Marca")).toBe("sem marca");
+  });
+});
+
+describe("chaveFenil", () => {
+  it("inteiros e escala 1 são idênticos no índice (numeric(10,1))", () => {
+    expect(chaveFenil(184)).toBe(184);
+    expect(chaveFenil(184.0)).toBe(184);
+  });
+
+  it("ruído além da escala 1 arredonda como numeric(10,1)", () => {
+    expect(chaveFenil(184.04)).toBe(184);
+    expect(chaveFenil(184.05)).toBe(184.1);
+    expect(chaveFenil(0)).toBe(0);
+    expect(chaveFenil(2040)).toBe(2040);
+  });
+});
+
+describe("chaveRef / chaveNomeMarca", () => {
+  it("chaveRef junta as 3 partes canônicas com o separador SOH (byte 001)", () => {
+    const soh = String.fromCharCode(1);
+    const chave = chaveRef(item("  Arroz  ", "Marca A", 184));
+
+    expect(chave).toBe(`arroz${soh}marca a${soh}184`);
+    expect(chave.split(soh)).toHaveLength(3);
+  });
+
+  it("marca sem marca ≡ produto in natura (matching §7.2)", () => {
+    expect(chaveRef(item("Feijão", "Produto In Natura", 100))).toBe(
+      chaveRef(item("feijão", "", 100)),
+    );
+    expect(chaveRef(item("Feijão", "não se aplica/produto in natura", 100))).toBe(
+      chaveRef(item("Feijão", "", 100)),
+    );
+  });
+
+  it("caixa e espaços de nome equivalem (como lower(trim) do índice)", () => {
+    expect(chaveRef(item(" ARROZ ", "", 184.0))).toBe(chaveRef(item("arroz", "", 184)));
+  });
+
+  it("fenil 184 ≡ 184.0, e escala difere da chave de outro fenil", () => {
+    expect(chaveRef(item("Arroz", "", 184))).toBe(chaveRef(item("Arroz", "", 184.0)));
+    expect(chaveRef(item("Arroz", "", 184))).not.toBe(chaveRef(item("Arroz", "", 185)));
+    expect(chaveRef(item("Arroz", "", 1))).not.toBe(chaveRef(item("Arroz", "", 10)));
+  });
+
+  it("'sem marca' textual NÃO equivale a '' (espelho literal das variantes)", () => {
+    expect(chaveMarca("sem marca")).not.toBe(chaveMarca(""));
+    expect(chaveRef(item("X", "sem marca", 1))).not.toBe(chaveRef(item("X", "", 1)));
+  });
+
+  it("fronteira entre campos não colide (concatenação é injetiva)", () => {
+    expect(chaveNomeMarca(item("AB", "", 1))).not.toBe(chaveNomeMarca(item("A", "B", 1)));
+    expect(chaveRef(item("AB", "", 1))).not.toBe(chaveRef(item("A", "B", 1)));
+    expect(chaveRef(item("Arroz", "", 2))).not.toBe(chaveRef(item("Arroz", "2", 2)));
+    expect(chaveRef(item("Feijão", "x", 1))).not.toBe(chaveRef(item("Feijão", "x", 12)));
+  });
+
+  it("chaveNomeMarca agrupa o que chaveRef separa por fenil", () => {
+    const base = chaveNomeMarca(item("Arroz", "Marca A", 100));
+
+    expect(chaveNomeMarca(item("Arroz", "Marca A", 150))).toBe(base);
+    expect(chaveNomeMarca(item("Arroz", "Outra Marca", 100))).not.toBe(base);
+    expect(chaveRef(item("Arroz", "Marca A", 100))).not.toBe(
+      chaveRef(item("Arroz", "Marca A", 150)),
+    );
+  });
+});

--- a/src/shared/referencias-sync/canonical.ts
+++ b/src/shared/referencias-sync/canonical.ts
@@ -1,0 +1,74 @@
+/**
+ * Chave canônica do motor de sincronização (FEAT-0017, D-8 — design §7.1/§7.2).
+ *
+ * Espelho EXATO do índice único parcial do banco:
+ *
+ *   `referencias_identidade_ativa_unique` (20260904040000, ENH-0004):
+ *   `btree (lower(trim(both from nome)), lower(trim(both from marca)),
+ *          fenil_mg_por_100g) where is_ativa`
+ *
+ * com `fenil_mg_por_100g numeric(10,1)`. A chave é aplicada AOS DOIS LADOS
+ * (origem e banco) para que "igual no motor" ≡ "igual no índice" — sem
+ * falsos-positivos de criação nem matching que o banco não aceitaria.
+ *
+ * Regras de marca (§7.2): para MATCHING, variantes textuais case-insensíveis
+ * de "sem marca" (espelho de `VARIANTES_SEM_MARCA` em
+ * `src/react-app/lib/referencias.ts`) E `produto in natura` mapeiam para ''
+ * — unificação determinística que evita pares ausência+criação artificiais
+ * por variação textual de marca. O VALOR persistido nunca é normalizado aqui
+ * (verbatim, fidelidade §3/§6); `normalizarMarca` (react-app) preserva
+ * 'Produto In Natura' de propósito — a chave de matching é deliberadamente
+ * mais larga (diferença documentada, não bug).
+ *
+ * Separador das chaves compostas: escape `\u0001` (SOH — design §7.1),
+ * textual no arquivo — NUNCA byte de controle cru (mesma convenção do `\u0000`
+ * da chave de duplicidade em `src/shared/powerbi/validate.ts`, que é par
+ * interno da validação e nunca se mistura com as chaves do motor).
+ */
+
+import type { IdentidadeReferencia } from "./types";
+
+/** Separador das chaves compostas (design §7.1 — SOH, escape textual). */
+const SEPARADOR_CHAVE = "\u0001";
+
+/** `VARIANTES_SEM_MARCA` de `src/react-app/lib/referencias.ts` + §7.2. */
+const SEM_MARCA_PARA_CHAVE = new Set([
+  "",
+  "não se aplica/produto in natura",
+  "nao se aplica/produto in natura",
+  "não se aplica (produto in natura)",
+  "nao se aplica (produto in natura)",
+  "produto in natura",
+]);
+
+export function chaveNome(nome: string): string {
+  return nome.trim().toLowerCase();
+}
+
+/** lower(trim) com as variantes "sem marca"/"produto in natura" → ''. */
+export function chaveMarca(marca: string): string {
+  const limpa = marca.trim().toLowerCase();
+  return SEM_MARCA_PARA_CHAVE.has(limpa) ? "" : limpa;
+}
+
+/**
+ * Fenil canônico: `round(numeric(10,1))` — o banco armazena escala 1
+ * (numeric(10,1) arredonda na escrita; origem é inteiro 0–2040 validado) e
+ * 184 ≡ 184.0 no índice. O arredondamento é no-op para os valores possíveis;
+ * existe para normalizar ruído numérico sem mudar a comparação do banco.
+ * Meio (x.5) arredonda para +∞ em valores positivos — igual ao numeric do
+ * Postgres (faixa 0–2040; negativos não ocorrem na origem validada).
+ */
+export function chaveFenil(fenil: number): number {
+  return Math.round(fenil * 10) / 10;
+}
+
+/** Par nome+marca canônico — agrupamento da substituição (§7.3). */
+export function chaveNomeMarca(item: IdentidadeReferencia): string {
+  return `${chaveNome(item.nome)}${SEPARADOR_CHAVE}${chaveMarca(item.marca)}`;
+}
+
+/** Chave completa nome+marca+fenil — identidade canônica (3 partes). */
+export function chaveRef(item: IdentidadeReferencia): string {
+  return `${chaveNome(item.nome)}${SEPARADOR_CHAVE}${chaveMarca(item.marca)}${SEPARADOR_CHAVE}${chaveFenil(item.fenil_mg_por_100g)}`;
+}

--- a/src/shared/referencias-sync/compare.test.ts
+++ b/src/shared/referencias-sync/compare.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from "vitest";
+import { comparar, derivarOrigemArquivada } from "./compare";
+import type { EntradaComparacao } from "./compare";
+import type { ArquivadaGlobal, GlobalAtiva, IdentidadeReferencia, ModoSync } from "./types";
+
+/**
+ * Comparação §7.3 — matriz linha a linha: matched | novo | ausente |
+ * substituição | reaparição | bloqueio manual | pendência aberta (D-6) |
+ * re-apresentação pós-rejeição (decisão humana 2026-09-06) | bootstrap.
+ */
+
+function base(modo: ModoSync = "pos_bootstrap"): EntradaComparacao {
+  return { origem: [], ativas: [], arquivadas: [], pendenciasAbertas: [], decisoes: [], modo };
+}
+
+function com(parcial: Partial<EntradaComparacao>): EntradaComparacao {
+  return { ...base(), ...parcial };
+}
+
+function item(nome: string, marca = "", fenil = 100): IdentidadeReferencia {
+  return { nome, marca, fenil_mg_por_100g: fenil };
+}
+
+function ativa(id: string, nome: string, marca = "", fenil = 100): GlobalAtiva {
+  return { id, ...item(nome, marca, fenil) };
+}
+
+function arquivada(
+  nome: string,
+  marca: string,
+  fenil: number,
+  eventos: { tipo: string; criadoEm: string }[],
+): ArquivadaGlobal {
+  return { ...item(nome, marca, fenil), eventos };
+}
+
+function evento(tipo: string, criadoEm: string): { tipo: string; criadoEm: string } {
+  return { tipo, criadoEm };
+}
+
+describe("derivarOrigemArquivada (B8(b), §6.4)", () => {
+  it("sem eventos decisivos (arquivo legado) → bloqueada_manual", () => {
+    expect(derivarOrigemArquivada([])).toBe("bloqueada_manual");
+    expect(derivarOrigemArquivada([evento("mudanca_aprovada", "2026-09-01T10:00:00Z")])).toBe(
+      "bloqueada_manual",
+    );
+  });
+
+  it("referencia_arquivada → arquivada_pela_origem", () => {
+    expect(
+      derivarOrigemArquivada([evento("referencia_arquivada", "2026-09-01T10:00:00Z")]),
+    ).toBe("arquivada_pela_origem");
+  });
+
+  it("is_ativa_manual e pre_sync_inativa → bloqueada_manual", () => {
+    expect(derivarOrigemArquivada([evento("is_ativa_manual", "2026-09-01T10:00:00Z")])).toBe(
+      "bloqueada_manual",
+    );
+    expect(derivarOrigemArquivada([evento("pre_sync_inativa", "2026-09-01T10:00:00Z")])).toBe(
+      "bloqueada_manual",
+    );
+  });
+
+  it("o último evento decisivo vence, independente da ordem da entrada", () => {
+    const arquivada10h = evento("referencia_arquivada", "2026-09-01T10:00:00Z");
+    const manual11h = evento("is_ativa_manual", "2026-09-01T11:00:00Z");
+    const arquivada12h = evento("referencia_arquivada", "2026-09-01T12:00:00Z");
+
+    expect(derivarOrigemArquivada([arquivada10h, manual11h])).toBe("bloqueada_manual");
+    expect(derivarOrigemArquivada([manual11h, arquivada10h])).toBe("bloqueada_manual");
+    expect(derivarOrigemArquivada([manual11h, arquivada12h])).toBe("arquivada_pela_origem");
+    expect(derivarOrigemArquivada([arquivada12h, manual11h])).toBe("arquivada_pela_origem");
+  });
+});
+
+describe("comparar — matched e equivalentes", () => {
+  it("matched: mesma identidade canônica nos dois lados → nada", () => {
+    const resultado = comparar(
+      com({ origem: [item("Arroz", "Marca A", 100)], ativas: [ativa("a1", "Arroz", "Marca A", 100)] }),
+    );
+
+    expect(resultado.equivalentes).toBe(1);
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.ativasParaArquivar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("matched com variação textual de marca/nome (§7.2 — matching é canônico)", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("feijão", "", 100)],
+        ativas: [ativa("a1", "Feijão", "Produto In Natura", 100)],
+      }),
+    );
+
+    expect(resultado.equivalentes).toBe(1);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("só o nome+marca canônico com fenil IGUAL é matched (184 ≡ 184.0)", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Arroz", "", 184.0)],
+        ativas: [ativa("a1", "Arroz", "", 184)],
+      }),
+    );
+
+    expect(resultado.equivalentes).toBe(1);
+  });
+});
+
+describe("comparar — novo (matriz §7.3)", () => {
+  it("pós-bootstrap: item sem correspondência → criar", () => {
+    const resultado = comparar(com({ origem: [item("Cuscuz", "", 5)] }));
+
+    expect(resultado.itensParaCriar).toEqual([item("Cuscuz", "", 5)]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("bootstrap: 1ª sync — zero auto, tudo vira pendência new_item", () => {
+    const resultado = comparar(com({ modo: "bootstrap", origem: [item("Cuscuz", "", 5)] }));
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([
+      { tipo: "new_item", referencia_id: null, proposta: item("Cuscuz", "", 5), diff: null },
+    ]);
+  });
+});
+
+describe("comparar — ausente (matriz §7.3)", () => {
+  it("pós-bootstrap: ativa sem correspondência na origem → arquivar", () => {
+    const resultado = comparar(com({ ativas: [ativa("a1", "Feijão Preto", "", 150)] }));
+
+    expect(resultado.ativasParaArquivar).toEqual([ativa("a1", "Feijão Preto", "", 150)]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("bootstrap: ausência vira pendência, nunca auto-arquiva", () => {
+    const resultado = comparar(com({ modo: "bootstrap", ativas: [ativa("a1", "Feijão Preto", "", 150)] }));
+
+    expect(resultado.ativasParaArquivar).toEqual([]);
+    expect(resultado.pendencias).toEqual([
+      { tipo: "absence", referencia_id: "a1", proposta: null, diff: null },
+    ]);
+  });
+
+  it("matched nunca é arquivada por ausência", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Arroz", "Marca A", 100)],
+        ativas: [
+          ativa("a1", "Arroz", "Marca A", 100),
+          ativa("a2", "Feijão", "", 200),
+        ],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([ativa("a2", "Feijão", "", 200)]);
+  });
+});
+
+describe("comparar — substituição (B7/§7.4: sempre pendência)", () => {
+  it("mesmo nome+marca, fenil diferente → pendência substitution nos DOIS modos", () => {
+    const resultadoPos = comparar(
+      com({
+        origem: [item("Arroz", "Marca A", 150)],
+        ativas: [ativa("a1", "Arroz", "Marca A", 100)],
+      }),
+    );
+    const resultadoBootstrap = comparar(
+      com({
+        modo: "bootstrap",
+        origem: [item("Arroz", "Marca A", 150)],
+        ativas: [ativa("a1", "Arroz", "Marca A", 100)],
+      }),
+    );
+
+    const pendenciaEsperada = [
+      {
+        tipo: "substitution" as const,
+        referencia_id: "a1",
+        proposta: item("Arroz", "Marca A", 150),
+        diff: [{ campo: "fenil_mg_por_100g", antes: 100, depois: 150 }],
+      },
+    ];
+
+    expect(resultadoPos.itensParaCriar).toEqual([]);
+    expect(resultadoPos.ativasParaArquivar).toEqual([]);
+    expect(resultadoPos.pendencias).toEqual(pendenciaEsperada);
+    expect(resultadoBootstrap.pendencias).toEqual(pendenciaEsperada);
+  });
+
+  it("diff é verbatim (nome/marca raw) e o alvo não vira ausência", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Feijão", "", 150)],
+        ativas: [ativa("a1", "Feijão", "Produto In Natura", 100)],
+      }),
+    );
+
+    expect(resultado.pendencias).toEqual([
+      {
+        tipo: "substitution",
+        referencia_id: "a1",
+        proposta: item("Feijão", "", 150),
+        diff: [
+          { campo: "marca", antes: "Produto In Natura", depois: "" },
+          { campo: "fenil_mg_por_100g", antes: 100, depois: 150 },
+        ],
+      },
+    ]);
+    expect(resultado.ativasParaArquivar).toEqual([]);
+  });
+
+  it("candidatas múltiplas: alvo = menor distância de fenil; empate → menor id; demais seguem ausência", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Arroz", "Marca A", 100)],
+        ativas: [
+          ativa("b", "Arroz", "Marca A", 140),
+          ativa("a", "Arroz", "Marca A", 90),
+          ativa("c", "Outro Produto", "", 999),
+        ],
+      }),
+    );
+
+    // distâncias: a(90)=10, b(140)=40 → alvo "a"; "b" fica ausente; "c" ausente.
+    expect(resultado.pendencias).toEqual([
+      {
+        tipo: "substitution",
+        referencia_id: "a",
+        proposta: item("Arroz", "Marca A", 100),
+        diff: [{ campo: "fenil_mg_por_100g", antes: 90, depois: 100 }],
+      },
+    ]);
+    expect(resultado.ativasParaArquivar).toEqual([
+      ativa("b", "Arroz", "Marca A", 140),
+      ativa("c", "Outro Produto", "", 999),
+    ]);
+  });
+
+  it("empate de distância: menor id vence (determinístico)", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Arroz", "Marca A", 100)],
+        ativas: [
+          ativa("z", "Arroz", "Marca A", 110),
+          ativa("a", "Arroz", "Marca A", 90),
+        ],
+      }),
+    );
+
+    expect(resultado.pendencias[0]?.referencia_id).toBe("a");
+  });
+});
+
+describe("comparar — reaparição e bloqueio manual (B8, §17)", () => {
+  it("arquivada_pela_origem que reaparece → recria (pós-bootstrap)", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Cuscuz", "", 5)],
+        arquivadas: [
+          arquivada("Cuscuz", "", 5, [evento("referencia_arquivada", "2026-09-01T10:00:00Z")]),
+        ],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([item("Cuscuz", "", 5)]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("bootstrap: reaparição segue o fluxo do novo (pendência, zero auto)", () => {
+    const resultado = comparar(
+      com({
+        modo: "bootstrap",
+        origem: [item("Cuscuz", "", 5)],
+        arquivadas: [
+          arquivada("Cuscuz", "", 5, [evento("referencia_arquivada", "2026-09-01T10:00:00Z")]),
+        ],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([
+      { tipo: "new_item", referencia_id: null, proposta: item("Cuscuz", "", 5), diff: null },
+    ]);
+  });
+
+  it("reaparição com bloqueio manual posterior → silêncio (nunca recria)", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Cuscuz", "", 5)],
+        arquivadas: [
+          arquivada("Cuscuz", "", 5, [
+            evento("referencia_arquivada", "2026-09-01T10:00:00Z"),
+            evento("is_ativa_manual", "2026-09-01T11:00:00Z"),
+          ]),
+        ],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("arquivada legada sem evento (default bloqueada_manual) e pre_sync_inativa → silêncio", () => {
+    for (const eventos of [
+      [],
+      [evento("pre_sync_inativa", "2026-09-01T10:00:00Z")],
+    ]) {
+      const resultado = comparar(
+        com({ origem: [item("Cuscuz", "", 5)], arquivadas: [arquivada("Cuscuz", "", 5, eventos)] }),
+      );
+
+      expect(resultado.itensParaCriar).toEqual([]);
+      expect(resultado.pendencias).toEqual([]);
+    }
+  });
+
+  it("arquivada com outra identidade não bloqueia o item", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Cuscuz", "", 5)],
+        arquivadas: [arquivada("Cuscuz", "", 50, [evento("is_ativa_manual", "2026-09-01T10:00:00Z")])],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([item("Cuscuz", "", 5)]);
+  });
+
+  it("arquivada_pela_origem que NÃO reapareceu não gera ação", () => {
+    const resultado = comparar(
+      com({ arquivadas: [arquivada("Cuscuz", "", 5, [evento("referencia_arquivada", "2026-09-01T10:00:00Z")])] }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.ativasParaArquivar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+});
+
+describe("comparar — pendência aberta suprime (D-6)", () => {
+  it("absence open no alvo: sem auto-arquivo e sem pendência nova", () => {
+    const resultado = comparar(
+      com({
+        ativas: [ativa("a1", "Feijão Preto", "", 150)],
+        pendenciasAbertas: [{ tipo: "absence", referencia_id: "a1", proposta: null }],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("new_item open com a MESMA proposta: sem criação e sem pendência nova", () => {
+    const proposta = item("Cuscuz", "", 5);
+    const resultado = comparar(
+      com({
+        origem: [proposta],
+        pendenciasAbertas: [{ tipo: "new_item", referencia_id: null, proposta }],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("substitution open cobre o alvo: origem não gera nada; outras ausências seguem", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Arroz", "Marca A", 150)],
+        ativas: [
+          ativa("a1", "Arroz", "Marca A", 100),
+          ativa("c", "Outro Produto", "", 999),
+        ],
+        pendenciasAbertas: [{ tipo: "substitution", referencia_id: "a1", proposta: item("Arroz", "Marca A", 150) }],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([]);
+    expect(resultado.ativasParaArquivar).toEqual([ativa("c", "Outro Produto", "", 999)]);
+  });
+
+  it("pendência aberta de outra divergência não suprime esta", () => {
+    const resultado = comparar(
+      com({
+        origem: [item("Cuscuz", "", 5)],
+        pendenciasAbertas: [{ tipo: "new_item", referencia_id: null, proposta: item("Outro", "", 7) }],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([item("Cuscuz", "", 5)]);
+  });
+});
+
+describe("comparar — re-apresentação pós-rejeição (decisão humana 2026-09-06)", () => {
+  it("ausência rejeitada: nunca auto-arquiva; divergência volta como pendência", () => {
+    const resultado = comparar(
+      com({
+        ativas: [ativa("a1", "Feijão Preto", "", 150)],
+        decisoes: [{ tipo: "absence", referencia_id: "a1", proposta: null, status: "rejected" }],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([]);
+    expect(resultado.pendencias).toEqual([
+      { tipo: "absence", referencia_id: "a1", proposta: null, diff: null },
+    ]);
+  });
+
+  it("new_item rejeitado: nunca cria automático; divergência volta como pendência", () => {
+    const proposta = item("Cuscuz", "", 5);
+    const resultado = comparar(
+      com({
+        origem: [proposta],
+        decisoes: [{ tipo: "new_item", referencia_id: null, proposta, status: "rejected" }],
+      }),
+    );
+
+    expect(resultado.itensParaCriar).toEqual([]);
+    expect(resultado.pendencias).toEqual([
+      { tipo: "new_item", referencia_id: null, proposta, diff: null },
+    ]);
+  });
+
+  it("decisão approved não suprime auto (sem memória especial de aprovado)", () => {
+    const resultado = comparar(
+      com({
+        ativas: [ativa("a1", "Feijão Preto", "", 150)],
+        decisoes: [{ tipo: "absence", referencia_id: "a1", proposta: null, status: "approved" }],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([ativa("a1", "Feijão Preto", "", 150)]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+
+  it("rejeição de outra divergência não suprime esta", () => {
+    const resultado = comparar(
+      com({
+        ativas: [ativa("a1", "Feijão Preto", "", 150)],
+        decisoes: [
+          { tipo: "absence", referencia_id: "a2", proposta: null, status: "rejected" },
+        ],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([ativa("a1", "Feijão Preto", "", 150)]);
+  });
+
+  it("última decisão cronológica vence (approved depois de rejected reautoriza)", () => {
+    const resultado = comparar(
+      com({
+        ativas: [ativa("a1", "Feijão Preto", "", 150)],
+        decisoes: [
+          { tipo: "absence", referencia_id: "a1", proposta: null, status: "rejected" },
+          { tipo: "absence", referencia_id: "a1", proposta: null, status: "approved" },
+        ],
+      }),
+    );
+
+    expect(resultado.ativasParaArquivar).toEqual([ativa("a1", "Feijão Preto", "", 150)]);
+    expect(resultado.pendencias).toEqual([]);
+  });
+});

--- a/src/shared/referencias-sync/compare.ts
+++ b/src/shared/referencias-sync/compare.ts
@@ -1,0 +1,279 @@
+/**
+ * Comparação bidirecional origem × banco (FEAT-0017, M3 — design §7.3).
+ *
+ * Entrada (contrato da rota, M4 — SEMPRE validada e deduplicada, §6.3):
+ * - `origem`: itens da extração validada; D-10 garante que linhas que dividem
+ *   nome+marca têm o MESMO fenil — logo, numa origem válida nenhuma global
+ *   com correspondência exata (matched) participa de um grupo de substituição;
+ * - `ativas`/`arquivadas`: SOMENTE globais (`is_global = true`) — pessoais
+ *   são intocadas (BR-034+; §7.3); arquivadas carregam os eventos de auditoria
+ *   da referência para a derivação do motivo do arquivamento (B8(b), §6.4);
+ * - `pendenciasAbertas`: pendências `open` de QUALQUER sync (D-6) — cobrem o
+ *   alvo (absence/substitution) ou a proposta (new_item): nem ação automática
+ *   nem pendência nova enquanto estiverem abertas;
+ * - `decisoes`: decisões `approved`/`rejected` de absence e new_item, em ordem
+ *   cronológica (a última vence). Memória de rejeição (decisão humana
+ *   2026-09-06): rejeição não cria regra permanente, mas o auto-apply nunca a
+ *   desfaz — a divergência volta como NOVA pendência enquanto persistir;
+ * - `modo`: `bootstrap` (1ª sync do ambiente — zero auto, tudo vira pendência)
+ *   vs. `pos_bootstrap` (auto: criar novo + arquivar ausente; substituição é
+ *   SEMPRE pendência, nos dois modos).
+ *
+ * Classificação por divergência (matriz §7.3):
+ *   matched                     → nada (equivalente)
+ *   novo                        → cria (pos_bootstrap) | pendência (bootstrap)
+ *   ausente                     → arquiva (pos_bootstrap) | pendência (bootstrap)
+ *   substituição                → pendência SEMPRE (nunca auto)
+ *   reaparição (arquivada_pela_origem) → recria (mesmo fluxo do novo)
+ *   reaparição de bloqueio manual      → silêncio (nunca recria contra
+ *                                        desativação humana)
+ *   divergência com pendência open     → nada (D-6, aguarda decisão)
+ *
+ * Garantias: este módulo NUNCA reativa, nunca toca `is_global = false`, nunca
+ * decide divergência e nunca exclui — o máximo que recomenda é `create`
+ * (novo id) e `archive` (`is_ativa = false`). Determinístico: mesmas entradas
+ * → mesma saída (idempotência §6.6 emerge no engine: 2ª execução com o estado
+ * pós-aplicação → tudo matched, zero operações).
+ */
+
+import { chaveFenil, chaveNomeMarca, chaveRef } from "./canonical";
+import type {
+  ArquivadaGlobal,
+  DecisaoPendencia,
+  DiffCampo,
+  EventoArquivada,
+  GlobalAtiva,
+  IdentidadeReferencia,
+  ModoSync,
+  OrigemArquivada,
+  PendenciaAberta,
+  PendenciaPlano,
+  StatusDecisao,
+} from "./types";
+
+/**
+ * Eventos de auditoria decisivos da derivação B8(b) (§6.4) — valores do enum
+ * `referencia_eventos.tipo` (M1, 20260905000000). `referencia_arquivada` =
+ * arquivamento decidido pela origem/sync; `is_ativa_manual` e
+ * `pre_sync_inativa` = bloqueio manual (curadoria/seed). Qualquer outro evento
+ * (ex.: `mudanca_aprovada`, `rollback`) é irrelevante para a derivação.
+ */
+const TIPO_EVENTO_ARQUIVADA = "referencia_arquivada";
+const TIPOS_EVENTO_BLOQUEIO_MANUAL = new Set(["is_ativa_manual", "pre_sync_inativa"]);
+
+export type EntradaComparacao = {
+  origem: IdentidadeReferencia[];
+  ativas: GlobalAtiva[];
+  arquivadas: ArquivadaGlobal[];
+  pendenciasAbertas: PendenciaAberta[];
+  decisoes: DecisaoPendencia[];
+  modo: ModoSync;
+};
+
+export type ResultadoComparacao = {
+  /** Matching sem ação (chaveRef presente nos dois lados). */
+  equivalentes: number;
+  /** Novos/reaparições a criar automaticamente (nunca no bootstrap). */
+  itensParaCriar: IdentidadeReferencia[];
+  /** Ausentes a arquivar automaticamente (nunca no bootstrap). */
+  ativasParaArquivar: GlobalAtiva[];
+  /** Pendências novas a criar (curadoria) — ordem determinística. */
+  pendencias: PendenciaPlano[];
+};
+
+/**
+ * Derivação B8(b) do motivo do arquivamento de uma global (§6.4): o último
+ * evento decisivo em ordem cronológica vence. Sem eventos decisivos (arquivo
+ * legado anterior à auditoria) → `bloqueada_manual` (default conservador:
+ * ausência de evidência não autoriza recriação automática). Empates de
+ * `criadoEm` mantêm a ordem da entrada (query da M4 é ORDER BY criadoEm).
+ */
+export function derivarOrigemArquivada(eventos: EventoArquivada[]): OrigemArquivada {
+  const decisivos = eventos
+    .slice()
+    .sort((a, b) => a.criadoEm.localeCompare(b.criadoEm))
+    .filter((evento) => TIPOS_EVENTO_BLOQUEIO_MANUAL.has(evento.tipo) || evento.tipo === TIPO_EVENTO_ARQUIVADA);
+
+  if (decisivos.length === 0) {
+    return "bloqueada_manual";
+  }
+
+  const ultimo = decisivos[decisivos.length - 1];
+  return ultimo.tipo === TIPO_EVENTO_ARQUIVADA ? "arquivada_pela_origem" : "bloqueada_manual";
+}
+
+export function comparar(entrada: EntradaComparacao): ResultadoComparacao {
+  const { origem, ativas, arquivadas, pendenciasAbertas, decisoes, modo } = entrada;
+
+  // Índice das ativas por identidade canônica completa (chaveRef).
+  const ativaPorChave = new Map<string, GlobalAtiva>();
+  for (const ativa of ativas) {
+    ativaPorChave.set(chaveRef(ativa), ativa);
+  }
+
+  // Índice de agrupamento da substituição: nome+marca → candidatas ativas.
+  const candidatasPorNomeMarca = new Map<string, GlobalAtiva[]>();
+  for (const ativa of ativas) {
+    const chave = chaveNomeMarca(ativa);
+    const grupo = candidatasPorNomeMarca.get(chave) ?? [];
+    grupo.push(ativa);
+    candidatasPorNomeMarca.set(chave, grupo);
+  }
+
+  const chavesDaOrigem = new Set(origem.map((item) => chaveRef(item)));
+
+  // D-6 — pendências open cobrem alvo (absence/substitution) ou proposta
+  // (new_item, por fingerprint da proposta). Alvo/proposta coberto: nada.
+  const alvosComPendenciaAberta = new Set<string>();
+  const propostasComPendenciaAberta = new Set<string>();
+  for (const pendencia of pendenciasAbertas) {
+    if (pendencia.tipo === "substitution" || pendencia.tipo === "absence") {
+      if (pendencia.referencia_id) {
+        alvosComPendenciaAberta.add(pendencia.referencia_id);
+      }
+    } else if (pendencia.proposta) {
+      propostasComPendenciaAberta.add(chaveRef(pendencia.proposta));
+    }
+  }
+
+  // Última decisão por divergência (entrada em ordem cronológica — a última
+  // vence; ver doc do módulo). Só a REJEIÇÃO como última decisão importa:
+  // suprime o auto (criação/arquivamento) e devolve a divergência ao fluxo
+  // de pendências (re-apresentação). Decisão posterior approved/cancelled
+  // reautoriza o auto — não guardamos memória de não-rejeições.
+  const statusAusencia = new Map<string, StatusDecisao>();
+  const statusNovo = new Map<string, StatusDecisao>();
+  for (const decisao of decisoes) {
+    if (decisao.tipo === "absence" && decisao.referencia_id) {
+      statusAusencia.set(decisao.referencia_id, decisao.status);
+    } else if (decisao.tipo === "new_item" && decisao.proposta) {
+      statusNovo.set(chaveRef(decisao.proposta), decisao.status);
+    }
+  }
+
+  // Reaparição × bloqueio manual: arquivada com MESMA identidade canônica e
+  // derivação manual silencia a divergência (nunca recriar contra decisão
+  // humana). Múltiplas arquivadas com a mesma identidade: prevalece o
+  // bloqueio manual, se houver (default conservador).
+  const bloqueioManualPorChave = new Map<string, boolean>();
+  for (const arquivada of arquivadas) {
+    const chave = chaveRef(arquivada);
+    const manual = derivarOrigemArquivada(arquivada.eventos) === "bloqueada_manual";
+    bloqueioManualPorChave.set(chave, (bloqueioManualPorChave.get(chave) ?? false) || manual);
+  }
+
+  const itensParaCriar: IdentidadeReferencia[] = [];
+  const pendencias: PendenciaPlano[] = [];
+  const alvosCobertosPorSubstituicao = new Set<string>();
+  let equivalentes = 0;
+
+  // Lado origem (ordem da entrada → saída determinística).
+  for (const item of origem) {
+    const chave = chaveRef(item);
+
+    if (ativaPorChave.has(chave)) {
+      equivalentes++;
+      continue;
+    }
+
+    // Divergência já coberta por pendência aberta de new_item (D-6).
+    if (propostasComPendenciaAberta.has(chave)) {
+      continue;
+    }
+
+    const candidatas = candidatasPorNomeMarca.get(chaveNomeMarca(item)) ?? [];
+
+    if (candidatas.length > 0) {
+      // Substituição: existe global ativa com o mesmo nome+marca e fenil
+      // DIFERENTE (por exclusão — a chave exata não está em ativaPorChave).
+      // SEMPRE pendência (B7/§7.4): mudança de fenil de item com marca é
+      // irreversível na ponta (foto diária) e merece curadoria.
+      // Determinismo do alvo quando há várias candidatas (origem válida não
+      // produz grupo misto — ver doc do módulo): menor distância de fenil
+      // canônico; empate → menor id; pula alvos com pendência aberta (D-6).
+      const ordenadas = candidatas
+        .slice()
+        .sort((a, b) => {
+          const distanciaA = Math.abs(chaveFenil(a.fenil_mg_por_100g) - chaveFenil(item.fenil_mg_por_100g));
+          const distanciaB = Math.abs(chaveFenil(b.fenil_mg_por_100g) - chaveFenil(item.fenil_mg_por_100g));
+          return distanciaA - distanciaB || a.id.localeCompare(b.id);
+        });
+      const alvo = ordenadas.find((candidata) => !alvosComPendenciaAberta.has(candidata.id));
+
+      if (!alvo) {
+        // Todas as candidatas cobertas por pendência aberta — aguarda (D-6).
+        continue;
+      }
+
+      // Cobre o alvo: sem isso ele seria também classificado como ausente.
+      alvosCobertosPorSubstituicao.add(alvo.id);
+      pendencias.push({
+        tipo: "substitution",
+        referencia_id: alvo.id,
+        proposta: item,
+        diff: diffSubstituicao(alvo, item),
+      });
+      continue;
+    }
+
+    // Sem ativa com nome+marca: novo — ou reaparição de arquivada (recria,
+    // §17) quando não houver bloqueio manual na mesma identidade canônica.
+    if (bloqueioManualPorChave.get(chave)) {
+      continue; // silêncio — humano desativou; presença na origem não é divergência
+    }
+
+    const rejeitada = statusNovo.get(chave) === "rejected";
+
+    if (modo === "bootstrap" || rejeitada) {
+      pendencias.push({ tipo: "new_item", referencia_id: null, proposta: item, diff: null });
+    } else {
+      itensParaCriar.push(item);
+    }
+  }
+
+  // Lado banco — ausências (ativas sem correspondência na origem). NUNCA
+  // cobre matched, alvo de substituição ou alvo com pendência aberta.
+  const ativasParaArquivar: GlobalAtiva[] = [];
+  for (const ativa of ativas) {
+    if (chavesDaOrigem.has(chaveRef(ativa))) {
+      continue;
+    }
+    if (alvosCobertosPorSubstituicao.has(ativa.id)) {
+      continue;
+    }
+    if (alvosComPendenciaAberta.has(ativa.id)) {
+      continue; // D-6 — aguarda decisão da pendência que cobre esta ausência
+    }
+
+    const rejeitada = statusAusencia.get(ativa.id) === "rejected";
+
+    if (modo === "bootstrap" || rejeitada) {
+      pendencias.push({ tipo: "absence", referencia_id: ativa.id, proposta: null, diff: null });
+    } else {
+      ativasParaArquivar.push(ativa);
+    }
+  }
+
+  return { equivalentes, itensParaCriar, ativasParaArquivar, pendencias };
+}
+
+/** Diff campo a campo alvo → proposta (verbatim, fidelidade §3/§6). */
+function diffSubstituicao(alvo: GlobalAtiva, item: IdentidadeReferencia): DiffCampo[] {
+  const diff: DiffCampo[] = [];
+
+  if (alvo.nome !== item.nome) {
+    diff.push({ campo: "nome", antes: alvo.nome, depois: item.nome });
+  }
+  if (alvo.marca !== item.marca) {
+    diff.push({ campo: "marca", antes: alvo.marca, depois: item.marca });
+  }
+  if (alvo.fenil_mg_por_100g !== item.fenil_mg_por_100g) {
+    diff.push({
+      campo: "fenil_mg_por_100g",
+      antes: alvo.fenil_mg_por_100g,
+      depois: item.fenil_mg_por_100g,
+    });
+  }
+
+  return diff;
+}

--- a/src/shared/referencias-sync/engine.test.ts
+++ b/src/shared/referencias-sync/engine.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { construirPlanoSync } from "./engine";
+import { PLANO_VERSAO } from "./types";
+import type { EntradaPlanoSync } from "./engine";
+import type { ArquivadaGlobal, GlobalAtiva, ModoSync } from "./types";
+import type { LinhaOrigem } from "../powerbi/types";
+
+/**
+ * Engine puro (§7.5): conversão linha→item (marca nula ≡ ''), dedupe de
+ * exatas mantendo a 1ª ocorrência, comparação e `p_plano` com resumo.
+ * Idempotência (§6.6): 2ª execução com o estado pós-aplicação → zero ops.
+ */
+
+function base(modo: ModoSync = "pos_bootstrap"): EntradaPlanoSync {
+  return { origem: [], ativas: [], arquivadas: [], pendenciasAbertas: [], decisoes: [], modo };
+}
+
+function com(parcial: Partial<EntradaPlanoSync>): EntradaPlanoSync {
+  return { ...base(), ...parcial };
+}
+
+function linha(nome: string, marca: string | null, fenil: number): LinhaOrigem {
+  return {
+    "Nome do Produto": nome,
+    "Marca do Produto": marca,
+    NU_MAX_AMINOACIDO: fenil,
+  };
+}
+
+function ativa(id: string, nome: string, marca: string, fenil: number): GlobalAtiva {
+  return { id, nome, marca, fenil_mg_por_100g: fenil };
+}
+
+function arquivada(
+  nome: string,
+  marca: string,
+  fenil: number,
+  eventos: { tipo: string; criadoEm: string }[],
+): ArquivadaGlobal {
+  return { nome, marca, fenil_mg_por_100g: fenil, eventos };
+}
+
+describe("construirPlanoSync — p_plano e resumo", () => {
+  it("plano pós-bootstrap: matched + novo, com contadores e versão", () => {
+    const plano = construirPlanoSync(
+      com({
+        origem: [linha("Arroz", "Marca A", 8), linha("Feijão", null, 12)],
+        ativas: [ativa("a1", "Arroz", "Marca A", 8)],
+      }),
+    );
+
+    expect(plano.versao).toBe(PLANO_VERSAO);
+    expect(plano.modo).toBe("pos_bootstrap");
+    expect(plano.criacoes).toEqual([
+      { op: "create", identidade: { nome: "Feijão", marca: "", fenil_mg_por_100g: 12 } },
+    ]);
+    expect(plano.arquivamentos).toEqual([]);
+    expect(plano.pendencias).toEqual([]);
+    expect(plano.resumo).toEqual({
+      totalOrigem: 2,
+      equivalentes: 1,
+      criadas: 1,
+      arquivadas: 0,
+      divergencias: 0,
+      pendencias: { substitution: 0, absence: 0, new_item: 0 },
+    });
+  });
+
+  it("bootstrap: tudo vira pendência — zero criações e zero arquivamentos", () => {
+    const plano = construirPlanoSync(
+      com({
+        modo: "bootstrap",
+        origem: [linha("Feijão", "", 12)],
+        ativas: [ativa("a1", "Arroz", "Marca A", 8)],
+      }),
+    );
+
+    expect(plano.criacoes).toEqual([]);
+    expect(plano.arquivamentos).toEqual([]);
+    expect(plano.pendencias).toEqual([
+      { tipo: "new_item", referencia_id: null, proposta: { nome: "Feijão", marca: "", fenil_mg_por_100g: 12 }, diff: null },
+      { tipo: "absence", referencia_id: "a1", proposta: null, diff: null },
+    ]);
+    expect(plano.resumo).toEqual({
+      totalOrigem: 1,
+      equivalentes: 0,
+      criadas: 0,
+      arquivadas: 0,
+      divergencias: 2,
+      pendencias: { substitution: 0, absence: 1, new_item: 1 },
+    });
+  });
+
+  it("dedupe de exatas: 1ª ocorrência vence; totalOrigem conta as linhas cruas", () => {
+    const plano = construirPlanoSync(
+      com({
+        origem: [
+          linha("Cuscuz", "Marca X", 5),
+          linha("Cuscuz", "Marca X", 5),
+          linha(" Cuscuz ", "MARCA X", 5),
+        ],
+      }),
+    );
+
+    expect(plano.criacoes).toHaveLength(1);
+    expect(plano.criacoes[0]?.identidade).toEqual({ nome: "Cuscuz", marca: "Marca X", fenil_mg_por_100g: 5 });
+    expect(plano.resumo.totalOrigem).toBe(3);
+    expect(plano.resumo.equivalentes).toBe(0);
+  });
+
+  it("marca nula ≡ marca '' na dedupe e na identidade criada", () => {
+    const plano = construirPlanoSync(
+      com({
+        origem: [linha("Produto", null, 7), linha("Produto", "", 7)],
+      }),
+    );
+
+    expect(plano.criacoes).toHaveLength(1);
+    expect(plano.criacoes[0]?.identidade.marca).toBe("");
+  });
+});
+
+describe("construirPlanoSync — idempotência (§6.6)", () => {
+  it("2ª execução com o estado pós-aplicação → zero operações", () => {
+    const origem = [linha("Arroz", "Marca A", 8), linha("Feijão", "", 12)];
+    const primeiro = construirPlanoSync(
+      com({ origem, ativas: [ativa("a1", "Arroz", "Marca A", 8)] }),
+    );
+
+    // Simula a aplicação do plano: cria Feijão (novo id f1) e arquiva a1.
+    const estadoPosAplicacao = {
+      ativas: [ativa("a1", "Arroz", "Marca A", 8), ativa("f1", "Feijão", "", 12)],
+      arquivadas: [] as ArquivadaGlobal[],
+    };
+
+    expect(primeiro.criacoes.map((c) => c.identidade)).toEqual([
+      { nome: "Feijão", marca: "", fenil_mg_por_100g: 12 },
+    ]);
+
+    const segundo = construirPlanoSync(com({ origem, ...estadoPosAplicacao }));
+
+    expect(segundo.criacoes).toEqual([]);
+    expect(segundo.arquivamentos).toEqual([]);
+    expect(segundo.pendencias).toEqual([]);
+    expect(segundo.resumo.equivalentes).toBe(2);
+    expect(segundo.resumo.divergencias).toBe(0);
+  });
+
+  it("ausência auto-arquivada some das ativas e não reaparece sem origem", () => {
+    const origem = [linha("Arroz", "Marca A", 8)];
+    const primeiro = construirPlanoSync(
+      com({
+        origem,
+        ativas: [ativa("a1", "Arroz", "Marca A", 8), ativa("b2", "Feijão", "", 12)],
+      }),
+    );
+
+    expect(primeiro.arquivamentos.map((a) => a.referencia_id)).toEqual(["b2"]);
+
+    const estadoPosAplicacao = {
+      ativas: [ativa("a1", "Arroz", "Marca A", 8)],
+      arquivadas: [arquivada("Feijão", "", 12, [evento("referencia_arquivada", "2026-09-01T10:00:00Z")])],
+    };
+
+    const segundo = construirPlanoSync(com({ origem, ...estadoPosAplicacao }));
+
+    expect(segundo.arquivamentos).toEqual([]);
+    expect(segundo.pendencias).toEqual([]);
+    expect(segundo.resumo.equivalentes).toBe(1);
+  });
+
+  it("item arquivado pela origem que REAPARECE é recriado (novo id — nunca reativa)", () => {
+    const origem = [linha("Arroz", "Marca A", 8), linha("Feijão", "", 12)];
+    const plano = construirPlanoSync(
+      com({
+        origem,
+        ativas: [ativa("a1", "Arroz", "Marca A", 8)],
+        arquivadas: [arquivada("Feijão", "", 12, [evento("referencia_arquivada", "2026-09-01T10:00:00Z")])],
+      }),
+    );
+
+    expect(plano.criacoes).toHaveLength(1);
+    expect(plano.arquivamentos).toEqual([]);
+  });
+});
+
+/** Helper de evento — só para o teste de idempotência acima. */
+function evento(tipo: string, criadoEm: string): { tipo: string; criadoEm: string } {
+  return { tipo, criadoEm };
+}

--- a/src/shared/referencias-sync/engine.ts
+++ b/src/shared/referencias-sync/engine.ts
@@ -1,0 +1,134 @@
+/**
+ * Motor puro de sincronização (FEAT-0017, M3 — design §7.5/§16): compõe a
+ * chave canônica (canonical.ts) e a comparação (compare.ts) e produz o plano
+ * de aplicação — o `p_plano jsonb` que a RPC `aplicar_sync_referencias` (M4)
+ * aplica numa transação única. Módulo sem efeitos: não lê nem escreve domínio,
+ * banco ou rede; entradas imutáveis, saída nova.
+ *
+ * Contrato da origem (rota/M4): linhas JÁ validadas por `validarExtracao`
+ * (estrutura, tipos, faixa fenil 0–2040, sem conflitantes D-10). A dedupe de
+ * exatas é feita aqui (mantém a 1ª ocorrência de cada identidade canônica);
+ * `resumo.totalOrigem` conta as linhas recebidas ANTES da dedupe (espelha o
+ * contador do banco).
+ *
+ * Idempotência (§6.6): dado o estado pós-aplicação (ativas = origem matched
+ * + criadas; ausentes arquivadas com evento), a 2ª execução com a mesma
+ * origem produz zero operações — toda divergência vira matched.
+ *
+ * Nunca: reativa, toca `is_global = false`, decide divergência ou exclui —
+ * as únicas operações emitidas são `create` (novo id) e `archive`.
+ */
+
+import { chaveRef } from "./canonical";
+import { comparar } from "./compare";
+import type { LinhaOrigem } from "../powerbi/types";
+import {
+  PLANO_VERSAO,
+  type ArquivadaGlobal,
+  type DecisaoPendencia,
+  type GlobalAtiva,
+  type IdentidadeReferencia,
+  type ModoSync,
+  type OperacaoArquivamento,
+  type OperacaoCriacao,
+  type PendenciaAberta,
+  type PlanoSync,
+  type ResumoPlano,
+  type TipoPendencia,
+} from "./types";
+
+export type EntradaPlanoSync = {
+  /** Linhas da origem extraídas e validadas (contrato §6.3). */
+  origem: LinhaOrigem[];
+  /** Globais ativas (`is_global = true` e `is_ativa = true`). */
+  ativas: GlobalAtiva[];
+  /** Globais arquivadas com eventos de auditoria (ordem cronológica). */
+  arquivadas: ArquivadaGlobal[];
+  /** Pendências `open` de qualquer sync (dedupe global, D-6). */
+  pendenciasAbertas: PendenciaAberta[];
+  /** Decisões approved/rejected de absence/new_item, ordem cronológica. */
+  decisoes: DecisaoPendencia[];
+  /** bootstrap = 1ª sync real do ambiente (zero auto) — ver compare.ts. */
+  modo: ModoSync;
+};
+
+/**
+ * Linha validada → identidade canônica (marca nula ≡ '', §6.3). O contrato da
+ * rota garante nome string não vazio, marca string ou nula e fenil numérico —
+ * estreitamento igual ao do `validate.ts` (o motor não revalida).
+ */
+function linhaParaItem(linha: LinhaOrigem): IdentidadeReferencia {
+  const marca = linha["Marca do Produto"];
+  return {
+    nome: linha["Nome do Produto"] as string,
+    marca: marca == null ? "" : (marca as string),
+    fenil_mg_por_100g: Number(linha["NU_MAX_AMINOACIDO"]),
+  };
+}
+
+/** Dedupe de exatas (§6.3.4): 1ª ocorrência de cada chave canônica vence. */
+function deduplicar(linhas: LinhaOrigem[]): IdentidadeReferencia[] {
+  const itens: IdentidadeReferencia[] = [];
+  const vistas = new Set<string>();
+
+  for (const linha of linhas) {
+    const item = linhaParaItem(linha);
+    const chave = chaveRef(item);
+    if (!vistas.has(chave)) {
+      vistas.add(chave);
+      itens.push(item);
+    }
+  }
+
+  return itens;
+}
+
+export function construirPlanoSync(entrada: EntradaPlanoSync): PlanoSync {
+  const itens = deduplicar(entrada.origem);
+  const resultado = comparar({
+    origem: itens,
+    ativas: entrada.ativas,
+    arquivadas: entrada.arquivadas,
+    pendenciasAbertas: entrada.pendenciasAbertas,
+    decisoes: entrada.decisoes,
+    modo: entrada.modo,
+  });
+
+  const criacoes: OperacaoCriacao[] = resultado.itensParaCriar.map((identidade) => ({
+    op: "create",
+    identidade,
+  }));
+
+  const arquivamentos: OperacaoArquivamento[] = resultado.ativasParaArquivar.map((ativa) => ({
+    op: "archive",
+    referencia_id: ativa.id,
+    identidade: { nome: ativa.nome, marca: ativa.marca, fenil_mg_por_100g: ativa.fenil_mg_por_100g },
+  }));
+
+  const pendenciasPorTipo: Record<TipoPendencia, number> = {
+    substitution: 0,
+    absence: 0,
+    new_item: 0,
+  };
+  for (const pendencia of resultado.pendencias) {
+    pendenciasPorTipo[pendencia.tipo]++;
+  }
+
+  const resumo: ResumoPlano = {
+    totalOrigem: entrada.origem.length,
+    equivalentes: resultado.equivalentes,
+    criadas: criacoes.length,
+    arquivadas: arquivamentos.length,
+    divergencias: resultado.pendencias.length,
+    pendencias: pendenciasPorTipo,
+  };
+
+  return {
+    versao: PLANO_VERSAO,
+    modo: entrada.modo,
+    criacoes,
+    arquivamentos,
+    pendencias: resultado.pendencias,
+    resumo,
+  };
+}

--- a/src/shared/referencias-sync/types.ts
+++ b/src/shared/referencias-sync/types.ts
@@ -1,0 +1,129 @@
+/**
+ * Modelo de dados do motor de sincronização de referências (FEAT-0017, M3) —
+ * tipos PUROS, sem escrita de domínio. Espelham o schema real do M1
+ * (`supabase/migrations/20260905000000_referencias_sync_tabelas.sql`) e a
+ * identidade canônica do banco (`referencias` — ENH-0004).
+ *
+ * O `PlanoSync` é o `p_plano jsonb` (design §7.5): a rota (M4) produz o plano
+ * no motor e o entrega à RPC `aplicar_sync_referencias` numa transação única.
+ * Chaves do jsonb = exatamente estes campos (camelCase); a RPC lê
+ * `criacoes`/`arquivamentos`/`pendencias` — não alterar sem migrar o SQL.
+ *
+ * Entradas do motor (M4 monta a partir do banco):
+ * - `ativas` e `arquivadas`: SOMENTE globais (`is_global = true`) — pessoais
+ *   são intocadas (BR-034+; design §7.3); ativas = `is_ativa`, arquivadas =
+ *   `is_ativa = false` com os eventos de auditoria da referência;
+ * - `pendenciasAbertas`: pendências `open` de QUALQUER sync (D-6 — dedupe
+ *   global de abertas, não apenas da sync corrente);
+ * - `decisoes`: pendências decididas (`approved`/`rejected`) de absence e
+ *   new_item, em ordem cronológica de decisão (a última vence) — alimentam a
+ *   re-apresentação pós-rejeição (decisão humana 2026-09-06; ver compare.ts).
+ */
+
+export const PLANO_VERSAO = 1 as const;
+
+/** Identidade oficial de uma referência — colunas de `referencias` (verbatim). */
+export type IdentidadeReferencia = {
+  nome: string;
+  marca: string;
+  fenil_mg_por_100g: number;
+};
+
+/** Global ativa (`is_global = true` e `is_ativa = true`). */
+export type GlobalAtiva = IdentidadeReferencia & { id: string };
+
+/** Global arquivada com os eventos de auditoria da referência (B8 derivação). */
+export type ArquivadaGlobal = IdentidadeReferencia & {
+  /** Eventos da referência em ordem cronológica (query da M4). */
+  eventos: EventoArquivada[];
+};
+
+/** Evento de auditoria relevante para a derivação do estado inativo (§6.4). */
+export type EventoArquivada = {
+  tipo: string;
+  criadoEm: string;
+};
+
+export type TipoPendencia = "substitution" | "absence" | "new_item";
+
+export type StatusDecisao = "approved" | "rejected";
+
+/** Pendência `open` (dedupe D-6 — bloqueia ação automática e nova pendência). */
+export type PendenciaAberta = {
+  tipo: TipoPendencia;
+  referencia_id: string | null;
+  proposta: IdentidadeReferencia | null;
+};
+
+/**
+ * Pendência decidida de absence/new_item — única memória pós-rejeição do
+ * motor (decisão humana 2026-09-06): rejeição não cria regra permanente, mas
+ * o auto-apply nunca a desfaz — a divergência volta como NOVA pendência
+ * enquanto persistir. Decisões de substitution não entram (substituição é
+ * sempre pendência; não há auto a suprimir).
+ */
+export type DecisaoPendencia = {
+  tipo: "absence" | "new_item";
+  referencia_id: string | null;
+  proposta: IdentidadeReferencia | null;
+  status: StatusDecisao;
+};
+
+/** Derivação B8(b) do estado inativo de uma global arquivada (§6.4). */
+export type OrigemArquivada = "arquivada_pela_origem" | "bloqueada_manual";
+
+/** 1ª sync do ambiente (zero auto) × sync confiável pós-bootstrap. */
+export type ModoSync = "bootstrap" | "pos_bootstrap";
+
+/** Mudança campo a campo para diff GitHub-like (design §5.2/§8). */
+export type DiffCampo = {
+  campo: "nome" | "marca" | "fenil_mg_por_100g";
+  antes: string | number;
+  depois: string | number;
+};
+
+/** Pendência a criar — espelho das colunas de `referencia_sync_pendencias`. */
+export type PendenciaPlano = {
+  tipo: TipoPendencia;
+  referencia_id: string | null;
+  proposta: IdentidadeReferencia | null;
+  diff: DiffCampo[] | null;
+};
+
+/** Aplicação automática: criação de nova global (nunca reativa, nunca UPDATE). */
+export type OperacaoCriacao = {
+  op: "create";
+  identidade: IdentidadeReferencia;
+};
+
+/** Aplicação automática: arquivamento por ausência (`is_ativa = false`). */
+export type OperacaoArquivamento = {
+  op: "archive";
+  referencia_id: string;
+  identidade: IdentidadeReferencia;
+};
+
+/** Contadores — espelham as colunas de `referencia_syncs` (§5.1). */
+export type ResumoPlano = {
+  /** Linhas recebidas da origem (antes da dedupe de exatas). */
+  totalOrigem: number;
+  /** Matching sem ação (design §7.3). */
+  equivalentes: number;
+  /** Criações automáticas (auto-apply pós-bootstrap). */
+  criadas: number;
+  /** Arquivamentos automáticos por ausência (pós-bootstrap). */
+  arquivadas: number;
+  /** Pendências novas a criar (curadoria). */
+  divergencias: number;
+  pendencias: Record<TipoPendencia, number>;
+};
+
+/** Plano de aplicação — `p_plano jsonb` da RPC `aplicar_sync_referencias`. */
+export type PlanoSync = {
+  versao: typeof PLANO_VERSAO;
+  modo: ModoSync;
+  criacoes: OperacaoCriacao[];
+  arquivamentos: OperacaoArquivamento[];
+  pendencias: PendenciaPlano[];
+  resumo: ResumoPlano;
+};


### PR DESCRIPTION
**Spec:** FEAT-0017 — ([.ai/specs/proposed/features/FEAT-0017-sincronizacao-referencias-anvisa.md](.ai/specs/proposed/features/FEAT-0017-sincronizacao-referencias-anvisa.md))
**Issue:** Part of #50
**Tipo:** FEAT
**Autorização:** Decision aprovada (B1–B10, rodadas R1–R3) — ver Spec
**Docs (wiki/):** N/A — sem FEAT/ENH release

## O que muda

M3 — Motor (Fase 4, design §16): módulo TS **puro** `src/shared/referencias-sync/`, sem escrita de domínio (rota inalterada; RPCs são M4). Espelha o schema M1 e o design §7.1–§7.5.

- `types.ts` — tipos puros espelhando `referencias_sync*`/`referencias` e o contrato do `p_plano jsonb` (camelCase, §7.5), incl. `DecisaoPendencia` (re-apresentação pós-rejeição).
- `canonical.ts` — `chaveRef` = `lower(trim(nome)) · lower(trim(marca)) · round(fenil)` com separador SOH textual no arquivo (nunca byte cru); espelho **exato** do UNIQUE parcial `referencias_identidade_ativa_unique` (ENH-0004, `numeric(10,1)`); variantes "sem marca"/`produto in natura` → `''` (§7.2, espelho de `VARIANTES_SEM_MARCA` do react-app).
- `compare.ts` — comparação bidirecional (matriz §7.3): matched | novo | ausente | substituição (sempre pendência; alvo determinístico por distância de fenil, empate por menor id, alvo coberto nunca vira ausência) | reaparição (recria) | reaparição de bloqueio manual (silêncio — derivação B8(b) por último evento decisivo; legado sem evento → `bloqueada_manual`) | pendência open suprime (D-6) | re-apresentação pós-rejeição (última decisão cronológica vence: rejected → pendência; approved/cancelled posteriores reautorizam auto).
- `engine.ts` — linha validada → item (marca nula ≡ `''`), dedupe de exatas (1ª ocorrência; `totalOrigem` conta linhas cruas), produz `PlanoSync` (`p_plano`) + resumo (contadores espelham colunas de `referencia_syncs`); idempotente (§6.6).

**Nunca:** reativa, toca `is_global = false`, decide divergência automaticamente, exclui fisicamente — as únicas operações emitidas são `create` (novo id) e `archive`.

## Evidências de validação

- ACs da FEAT-0017 cobertas por milestone (M3 sem AC final próprio; validação final em M7).
- Matriz §7.3 linha a linha coberta por testes; decisão humana 2026-09-06 (re-apresentação pós-rejeição) testada; D-6 testado; §7.2 testado; boundary chave canônica × UNIQUE do banco testado.
- Sem migration (RPCs = M4); sem mudança de Current Specs (módulo puro não integrado — sem comportamento factual documentado alterado; matriz CONVENTIONS §11 avaliada).

## Testes

- `npm run build` (tsc -b && vite build) — verde
- `npm run test:run` — **526/526** (473 pré-existentes + 53 novos: canonical 16 · compare 31 · engine 7)
- `npx eslint src/shared/referencias-sync/` — limpo

## Segurança

- Módulo puro sem I/O (banco/rede/domínio intocados); rota, RLS e RPCs inalterados.
- Garantias de segurança preservadas por construção: motor nunca reativa, nunca decide divergência, nunca toca referências pessoais (`is_global = false`).

## Checklist

- [ ] ACs validadas com evidência (acima; validação final em M7)
- [ ] Current Specs sincronizadas (matriz CONVENTIONS §11): **N/A** — sem mudança factual (avaliado)
- [ ] Testes: `npm run build` verde · 526/526 · eslint limpo
- [ ] Sem mudança HIGH sem autorização explícita (FEAT ACCEPTED + design aprovado cobrem o escopo; M3 sem migration/schema/RLS/RPC)
- [ ] `release-gate` (W7, PR de release → master): N/A — PR para `development`
- [ ] Merge: aguardando aprovação humana do PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)