### PR TITLE
fix(feat-0017): extensão .js nos imports internos de src/shared/ (ESM Node.js)

### DIFF
--- a/.ai/specs/proposed/index.md
+++ b/.ai/specs/proposed/index.md
@@ -1,8 +1,8 @@
 # Proposed — Catálogo de Evoluções Possíveis
 
-**Última verificação:** 2026-09-07 (FEAT-0017 arquivada como IMPLEMENTED — PRs #57–#62 — 12 ativas + 7 arquivadas)
+**Última verificação:** 2026-09-10 (DEBT-0007 registrada — 13 ativas + 7 arquivadas)
 
-> Semântica das contagens: ativas = linhas do Catálogo com Status **PROPOSED** (12) · arquivadas = linhas da seção "Arquivadas" (7) · as 6 linhas **IMPLEMENTED** históricas (REF-0003, DEBT-0005, DEBT-0006, REF-0004, ENH-0004, FEAT-0017) permanecem no Catálogo, fora das contagens.
+> Semântica das contagens: ativas = linhas do Catálogo com Status **PROPOSED** (13) · arquivadas = linhas da seção "Arquivadas" (7) · as 6 linhas **IMPLEMENTED** históricas (REF-0003, DEBT-0005, DEBT-0006, REF-0004, ENH-0004, FEAT-0017) permanecem no Catálogo, fora das contagens.
 
 > ⚠️ Este diretório contém POSSIBILIDADES FUTURAS. NADA aqui é comportamento atual, decisão tomada ou plano comprometido. Status inicial de toda proposta: **PROPOSED**. O estado atual do sistema está documentado exclusivamente em `../current/`.
 >
@@ -30,6 +30,7 @@
 | [FEAT-0017](../archive/implemented/features/FEAT-0017-sincronizacao-referencias-anvisa.md) | FEAT | Sincronização controlada de referências com a fonte ANVISA/Power BI | IMPLEMENTED | #50 | Draft 001-auto-refresh-database (arquivado) — refinamento 2026-09-02 · M1–M6 (PRs #57–#62, merges `5b1ed18`/`7ec0bf5`/`dd631d6`/`6e7d3e5`/`cb5d776`/`cb1123d`) + specs finais (M7) — 2026-09-05/06/07 |
 | [REF-0004](../archive/implemented/refactors/REF-0004-automacao-residuo-gate-e-prevencao-tentativa-erro.md) | REF | Automação de limpeza de resíduo do gate + padrão preventivo para release | IMPLEMENTED | #51 | W7 + ADR-0013 — descoberto no PR #48 (release v1.10.0), PR #52 (squash merge) — 2026-09-03 |
 | [REF-0005](refactors/REF-0005-heading-canonico-corpo-release-pre-release-check-ampliado.md) | REF | Corpo de Release com heading canônico da tabela de rastreabilidade + pre-release-check ampliado | PROPOSED | #54 | W6 `no-table` em v1.10.0 (run 33139076564) e v1.10.1 (run 33826721637) — 2026-09-03 |
+| [DEBT-0007](technical-debt/DEBT-0007-gate-validacao-rotas-vercel.md) | DEBT | Gate de validação não cobre rotas Vercel em modo Node.js ESM | PROPOSED | TBD | ERR_MODULE_NOT_FOUND em prod (v1.11.0, 2026-09-10) — fix `2ea335c` |
 
 ## Arquivadas
 

--- a/.ai/specs/proposed/technical-debt/DEBT-0007-gate-validacao-rotas-vercel.md
+++ b/.ai/specs/proposed/technical-debt/DEBT-0007-gate-validacao-rotas-vercel.md
@@ -1,0 +1,100 @@
+# DEBT-0007 — Gate de validação não cobre rotas Vercel em modo Node.js ESM
+
+**Type:** DEBT
+**Status:** PROPOSED
+**Title:** Gate de validação não cobre rotas Vercel em modo Node.js ESM
+**Issue:** TBD
+**Created on:** 2026-09-10
+
+## Problem
+
+O gate local de validação (`tsc -b && vite build && npm run test:run`) não detecta erros de resolução de módulos ESM que só se manifestam no runtime do Vercel, levando bugs de deploy a passar por todos os checks automatizados.
+
+## Current State
+
+O gate de validação cobre três etapas (ver [testing-strategy.md](../../current/testing/testing-strategy.md)):
+- `tsc -b` — type-check com `moduleResolution: Bundler` (não exige `.js` em imports relativos)
+- `vite build` — compila apenas a SPA React em `src/react-app/`; não toca `api/`
+- `npm run test:run` — Vitest com resolução bundler (extensões automáticas)
+
+As funções serverless em `api/` são compiladas pelo Vercel com esbuild em **Node.js ESM estrito**, que exige extensão `.js` explícita em imports relativos. Essa compilação só ocorre no deploy — nunca localmente.
+
+## Proposed State
+
+Ao menos uma etapa do gate detecta imports relativos sem `.js` nos arquivos de `src/shared/` que são importados por `api/`. Opcões possíveis (decisão humana):
+
+- **A — tsconfig dedicado para `api/`** com `"moduleResolution": "NodeNext"`, incluindo `src/shared/` no escopo. O `tsc -b` passa a exigir `.js` e falha em tempo de type-check.
+- **B — lint rule** (`import/extensions` via eslint-plugin-import ou similar) aplicada a `api/` e `src/shared/`.
+- **C — teste de smoke de import** em Node.js ESM puro (sem Vite/bundler) cobrindo o grafo de imports de `api/referencias-sync.ts`.
+
+## Motivation
+
+**FACTUAL:** Em 2026-09-10, `api/referencias-sync.ts` foi deployada com imports de `src/shared/powerbi/decode`, `query-payload`, `validate`, `canonical`, `compare` e `engine` sem extensão `.js`. O Vercel falhou em runtime com `ERR_MODULE_NOT_FOUND` no botão de sync — detectado apenas durante testes manuais pós-release, não pelo gate automatizado.
+
+**FACTUAL:** O gate local passou completamente (build verde, 618 testes verdes) porque Vite e Vitest resolvem extensões automaticamente no modo bundler.
+
+## Evidence
+
+- Bug detectado em 2026-09-10 durante testes manuais de `v1.11.0` (FEAT-0017).
+- Fix aplicado em `fix/esm-extensions-shared-modules` (`2ea335c`) — 6 arquivos, 12 imports corrigidos.
+- Causa raiz: mismatch entre `moduleResolution: Bundler` (gate local) e Node.js ESM estrito (Vercel runtime).
+
+## Scope
+
+- Adicionar etapa ao gate que cubra resolução de módulos ESM em `api/` e `src/shared/`.
+- A etapa deve falhar em CI (W1) quando imports relativos sem `.js` forem detectados.
+
+## Out of Scope
+
+- Mudar o `moduleResolution` global do projeto (afetaria `src/react-app/` desnecessariamente).
+- Instalar ou configurar o Vercel CLI para testes locais de funções (melhoria separada).
+
+## Impacted Features
+
+- FEAT-0017 (sincronização de referências) — rota `api/referencias-sync.ts` é o único ponto de deploy afetado atualmente.
+
+## Impacted Business Rules
+
+N/A
+
+## Impacted Architecture
+
+- [testing-strategy.md](../../current/testing/testing-strategy.md) — gate W1 precisa ser estendido.
+- [secrets-and-environments.md](../../current/security/secrets-and-environments.md) — ambiente de execução das rotas Vercel documentado ali.
+
+## Impacted Frontend / Backend / Database / Security / Tests
+
+- **Backend:** `api/` e `src/shared/` (grafo de imports das rotas Vercel).
+- **Tests:** gate W1 (`tsc -b` ou lint ou smoke test).
+- Frontend / Database / Security: N/A.
+
+## Dependencies
+
+Nenhuma.
+
+## Risks
+
+- **Alternativa A (tsconfig NodeNext):** pode exigir ajuste em outros imports de `src/shared/` usados por testes — baixo risco, já que Vitest ignora o tsconfig de produção.
+- **Alternativa B (lint rule):** requer instalação de plugin; pode ter falsos positivos em imports de pacotes externos.
+- **Alternativa C (smoke test):** mais frágil — depende de como o Node.js é invocado; pode divergir do comportamento do esbuild do Vercel.
+
+## Alternatives
+
+**Decision:** TBD — a escolha entre A, B e C é humana.
+
+## Open Questions
+
+1. Qual alternativa (A/B/C) tem melhor custo-benefício para o projeto?
+2. A cobertura deve incluir apenas `api/referencias-sync.ts` ou todas as rotas futuras de `api/`?
+
+## Acceptance Criteria
+
+- [ ] O gate local (`npm run build` ou `npm run lint`) **falha** quando um import relativo sem `.js` é adicionado em `src/shared/` ou `api/`.
+- [ ] O CI (W1) também falha na mesma condição.
+- [ ] Nenhum falso positivo em imports de pacotes externos (ex.: `@supabase/supabase-js`).
+
+## References
+
+- Fix: `fix/esm-extensions-shared-modules`, commit `2ea335c`
+- [api-referencias-sync.md](../../current/backend/api-referencias-sync.md)
+- [testing-strategy.md](../../current/testing/testing-strategy.md)

--- a/src/shared/powerbi/decode.ts
+++ b/src/shared/powerbi/decode.ts
@@ -23,7 +23,7 @@ import {
   type LinhaDsrBruta,
   type LinhaOrigem,
   type RespostaPowerBi,
-} from "./types";
+} from "./types.js";
 
 /** Erro estrutural do DSR (resposta/forma inesperadas — fail-high). */
 export class ErroEstruturalDsr extends Error {}

--- a/src/shared/powerbi/extract.ts
+++ b/src/shared/powerbi/extract.ts
@@ -13,9 +13,9 @@
  * - resposta HTTP não-ok → erro explícito (`status statusText`).
  */
 
-import { decodeDsr } from "./decode";
-import { QUERY_PAYLOAD, type PayloadConsultaPowerBi } from "./query-payload";
-import type { LinhaOrigem } from "./types";
+import { decodeDsr } from "./decode.js";
+import { QUERY_PAYLOAD, type PayloadConsultaPowerBi } from "./query-payload.js";
+import type { LinhaOrigem } from "./types.js";
 
 export const QUERY_DATA_URL =
   "https://wabi-brazil-south-api.analysis.windows.net/public/reports/querydata?synchronous=true";

--- a/src/shared/powerbi/validate.ts
+++ b/src/shared/powerbi/validate.ts
@@ -22,7 +22,7 @@
  * (lower/trim — ENH-0004); o módulo canônico completo vive no motor (M3).
  */
 
-import { COLUNAS_ORIGEM, FENIL_MAX, FENIL_MIN, type LinhaOrigem } from "./types";
+import { COLUNAS_ORIGEM, FENIL_MAX, FENIL_MIN, type LinhaOrigem } from "./types.js";
 
 export const CHAVE_COLUNAS_ESPERADAS = [...COLUNAS_ORIGEM].sort();
 

--- a/src/shared/referencias-sync/canonical.ts
+++ b/src/shared/referencias-sync/canonical.ts
@@ -26,7 +26,7 @@
  * interno da validação e nunca se mistura com as chaves do motor).
  */
 
-import type { IdentidadeReferencia } from "./types";
+import type { IdentidadeReferencia } from "./types.js";
 
 /** Separador das chaves compostas (design §7.1 — SOH, escape textual). */
 const SEPARADOR_CHAVE = "\u0001";

--- a/src/shared/referencias-sync/compare.ts
+++ b/src/shared/referencias-sync/compare.ts
@@ -39,7 +39,7 @@
  * pós-aplicação → tudo matched, zero operações).
  */
 
-import { chaveFenil, chaveNomeMarca, chaveRef } from "./canonical";
+import { chaveFenil, chaveNomeMarca, chaveRef } from "./canonical.js";
 import type {
   ArquivadaGlobal,
   DecisaoPendencia,
@@ -52,7 +52,7 @@ import type {
   PendenciaAberta,
   PendenciaPlano,
   StatusDecisao,
-} from "./types";
+} from "./types.js";
 
 /**
  * Eventos de auditoria decisivos da derivação B8(b) (§6.4) — valores do enum

--- a/src/shared/referencias-sync/engine.ts
+++ b/src/shared/referencias-sync/engine.ts
@@ -19,9 +19,9 @@
  * as únicas operações emitidas são `create` (novo id) e `archive`.
  */
 
-import { chaveRef } from "./canonical";
-import { comparar } from "./compare";
-import type { LinhaOrigem } from "../powerbi/types";
+import { chaveRef } from "./canonical.js";
+import { comparar } from "./compare.js";
+import type { LinhaOrigem } from "../powerbi/types.js";
 import {
   PLANO_VERSAO,
   type ArquivadaGlobal,
@@ -35,7 +35,7 @@ import {
   type PlanoSync,
   type ResumoPlano,
   type TipoPendencia,
-} from "./types";
+} from "./types.js";
 
 export type EntradaPlanoSync = {
   /** Linhas da origem extraídas e validadas (contrato §6.3). */


### PR DESCRIPTION
## Summary

- Corrige `ERR_MODULE_NOT_FOUND` em runtime no Vercel ao acionar o botão de sync ou o cron de referências (FEAT-0017).
- Causa: `src/shared/powerbi/` e `src/shared/referencias-sync/` usavam imports relativos sem extensão `.js`. O Vite/Vitest resolve automaticamente, mas o runtime Node.js ESM estrito do Vercel exige extensão explícita.
- 6 arquivos corrigidos: `decode.ts`, `extract.ts`, `validate.ts`, `canonical.ts`, `compare.ts`, `engine.ts`.
- Registrada DEBT-0007 para cobrir a lacuna no gate de validação (tsconfig NodeNext / lint rule / smoke test — decisão humana pendente).

## Rastreabilidade

| Spec | Issue | PR | Título | Tipo |
|------|-------|----|--------|------|
| DEBT-0007 | TBD | este PR | Gate de validação não cobre rotas Vercel em modo Node.js ESM | DEBT |

## Testes

- `npm run build` (tsc -b + vite build): verde
- `npm run test:run` (módulos afetados — 6 suítes / 102 testes): verde
- Verificação runtime: via preview deployment deste PR (testar botão "Executar sync agora" no Admin)

## Segurança

Nenhuma alteração de segurança, RLS, autorização ou contrato externo.

## Checklist

- [x] ACs validadas com evidência (build + testes verdes; runtime via preview)
- [x] Current Specs: nenhuma alteração de comportamento — docs não afetadas
- [x] DEBT-0007 registrada em `proposed/technical-debt/`
- [x] Sem mudança HIGH sem autorização
- [x] Merge: aguardando aprovação humana do PR